### PR TITLE
[iOS] 여정 목록 UI 수정

### DIFF
--- a/iOS/Features/Home/Package.swift
+++ b/iOS/Features/Home/Package.swift
@@ -54,9 +54,7 @@ let package = Package(
         .package(name: Dependency.journeyList,
                  path: Dependency.journeyList.fromCurrentPath),
         .package(name: Dependency.msUIKit,
-                 path: Dependency.msUIKit.fromRootPath),
-        .package(name: Dependency.msCoreKit,
-                 path: Dependency.msCoreKit.fromRootPath)
+                 path: Dependency.msUIKit.fromRootPath)
     ],
     targets: [
         .target(name: Target.home,

--- a/iOS/Features/Home/Sources/Home/HomeBottomSheetViewController.swift
+++ b/iOS/Features/Home/Sources/Home/HomeBottomSheetViewController.swift
@@ -25,4 +25,10 @@ public final class HomeBottomSheetViewController
     
     public weak var delegate: HomeViewControllerDelegate?
     
+    public override func viewIsAppearing(_ animated: Bool) {
+        super.viewIsAppearing(animated)
+        
+        self.navigationController?.isNavigationBarHidden = true
+    }
+    
 }

--- a/iOS/Features/Home/Sources/Home/HomeBottomSheetViewController.swift
+++ b/iOS/Features/Home/Sources/Home/HomeBottomSheetViewController.swift
@@ -18,7 +18,8 @@ public protocol HomeViewControllerDelegate: AnyObject {
     
 }
 
-public final class HomeBottomSheetViewController: MSBottomSheetViewController<NavigateMapViewController, JourneyListViewController> {
+public final class HomeBottomSheetViewController
+: MSBottomSheetViewController<NavigateMapViewController, JourneyListViewController> {
     
     // MARK: - Properties
     

--- a/iOS/Features/Home/Sources/Home/HomeBottomSheetViewController.swift
+++ b/iOS/Features/Home/Sources/Home/HomeBottomSheetViewController.swift
@@ -18,8 +18,32 @@ public protocol HomeViewControllerDelegate: AnyObject {
     
 }
 
-public final class HomeBottomSheetViewController
-: MSBottomSheetViewController<NavigateMapViewController, JourneyListViewController> {
+public typealias HomeViewController = MSBottomSheetViewController<NavigateMapViewController, JourneyListViewController>
+
+public final class HomeBottomSheetViewController: HomeViewController {
+    
+    // MARK: - Constants
+    
+    private enum Typo {
+        
+        static let startButtonTitle = "시작하기"
+        
+    }
+    
+    private enum Metric {
+        
+        static let startButtonBottomInset: CGFloat = 16.0
+        
+    }
+    
+    // MARK: - UI Components
+    
+    private let startButton: MSButton = {
+        let button = MSButton.primary()
+        button.cornerStyle = .rounded
+        button.title = Typo.startButtonTitle
+        return button
+    }()
     
     // MARK: - Properties
     
@@ -29,6 +53,30 @@ public final class HomeBottomSheetViewController
         super.viewIsAppearing(animated)
         
         self.navigationController?.isNavigationBarHidden = true
+    }
+    
+    // MARK: - Life Cycle
+    
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        self.configureLayout()
+    }
+    
+}
+
+// MARK: - UI Configuration
+
+private extension HomeBottomSheetViewController {
+    
+    func configureLayout() {
+        self.view.addSubview(self.startButton)
+        self.startButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            self.startButton.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+            self.startButton.bottomAnchor.constraint(equalTo: self.bottomSheetViewController.view.topAnchor,
+                                                     constant: -Metric.startButtonBottomInset)
+        ])
     }
     
 }

--- a/iOS/Features/Home/Sources/NavigateMap/Presentation/NavigateMapViewController.swift
+++ b/iOS/Features/Home/Sources/NavigateMap/Presentation/NavigateMapViewController.swift
@@ -27,14 +27,6 @@ public final class NavigateMapViewController: UIViewController {
 
         return stackView
     }()
-
-    /// 시작하기 Button
-    private let startButton: MSButton = {
-        let button = MSButton.primary()
-        button.cornerStyle = .rounded
-        button.title = "시작하기"
-        return button
-    }()
     
     @objc func findMyLocation() {
         
@@ -62,8 +54,6 @@ public final class NavigateMapViewController: UIViewController {
         
         view = mapView
         
-        startButton.addTarget(self, action: #selector(findMyLocation), for: .touchUpInside)
-        
         locationManager.requestWhenInUseAuthorization()
         mapView.map.setRegion(MKCoordinateRegion(center: tempCoordinate,
                                                  span: MKCoordinateSpan(latitudeDelta: 0.1, longitudeDelta: 0.11)),
@@ -83,11 +73,9 @@ public final class NavigateMapViewController: UIViewController {
 
     private func configureLayout() {
         view.addSubview(buttonStackView)
-        view.addSubview(startButton)
         
         mapView.map.translatesAutoresizingMaskIntoConstraints = false
         buttonStackView.translatesAutoresizingMaskIntoConstraints = false
-        startButton.translatesAutoresizingMaskIntoConstraints = false
 
         let safeArea = self.view.safeAreaLayoutGuide
 
@@ -98,10 +86,7 @@ public final class NavigateMapViewController: UIViewController {
             self.mapView.map.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
 
             self.buttonStackView.topAnchor.constraint(equalTo: safeArea.topAnchor, constant: 50),
-            self.buttonStackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
-
-            self.startButton.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor, constant: -80),
-            self.startButton.centerXAnchor.constraint(equalTo: view.centerXAnchor)
+            self.buttonStackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16)
         ])
     }
     

--- a/iOS/Features/JourneyList/.swiftpm/xcode/xcshareddata/xcschemes/JourneyList.xcscheme
+++ b/iOS/Features/JourneyList/.swiftpm/xcode/xcshareddata/xcschemes/JourneyList.xcscheme
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "JourneyList"
+               BuildableName = "JourneyList"
+               BlueprintName = "JourneyList"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "JourneyList"
+            BuildableName = "JourneyList"
+            BlueprintName = "JourneyList"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/iOS/Features/JourneyList/Sources/JourneyList/Presentation/JourneyListViewController.swift
+++ b/iOS/Features/JourneyList/Sources/JourneyList/Presentation/JourneyListViewController.swift
@@ -20,23 +20,26 @@ public protocol JourneyListViewControllerDelegate: AnyObject {
 public final class JourneyListViewController: BaseViewController {
     
     typealias JourneyListDataSource = UICollectionViewDiffableDataSource<Int, Journey>
+    typealias JourneyListHeaderRegistration = UICollectionView.SupplementaryRegistration<JourneyListHeaderView>
     typealias JourneyCellRegistration = UICollectionView.CellRegistration<JourneyCell, Journey>
     typealias JourneySnapshot = NSDiffableDataSourceSnapshot<Int, Journey>
     
     // MARK: - Constants
     
     private enum Typo {
-        static let title: String = "지난 여정"
+        
         static func subtitle(numberOfJourneys: Int) -> String {
             return "현재 위치에 \(numberOfJourneys)개의 여정이 있습니다."
         }
+        
     }
     
     private enum Metric {
-        static let titleStackSpacing: CGFloat = 4.0
+        
         static let collectionViewHorizontalInset: CGFloat = 10.0
         static let collectionViewVerticalInset: CGFloat = 24.0
         static let interGroupSpacing: CGFloat = 12.0
+        
     }
     
     // MARK: - Properties
@@ -57,31 +60,8 @@ public final class JourneyListViewController: BaseViewController {
     
     // MARK: - UI Components
     
-    private let titleStack: UIStackView = {
-        let stackView = UIStackView()
-        stackView.axis = .vertical
-        stackView.spacing = Metric.titleStackSpacing
-        return stackView
-    }()
-    
-    private let titleLabel: UILabel = {
-        let label = UILabel()
-        label.font = .msFont(.headerTitle)
-        label.textColor = .msColor(.primaryTypo)
-        label.text = Typo.title
-        return label
-    }()
-    
-    private let subtitleLabel: UILabel = {
-        let label = UILabel()
-        label.font = .msFont(.caption)
-        label.textColor = .msColor(.secondaryTypo)
-        label.text = Typo.subtitle(numberOfJourneys: 0)
-        return label
-    }()
-    
-    private lazy var collectionView: UICollectionView = {
-        let collectionView = UICollectionView(frame: .zero,
+    private lazy var collectionView: MSCollectionView = {
+        let collectionView = MSCollectionView(frame: .zero,
                                               collectionViewLayout: UICollectionViewLayout())
         collectionView.backgroundColor = .clear
         collectionView.delegate = self
@@ -120,7 +100,6 @@ public final class JourneyListViewController: BaseViewController {
         self.viewModel.state.journeys
             .receive(on: DispatchQueue.main)
             .sink { journeys in
-                self.subtitleLabel.text = Typo.subtitle(numberOfJourneys: journeys.count)
                 var snapshot = JourneySnapshot()
                 snapshot.appendSections([.zero])
                 snapshot.appendItems(journeys, toSection: .zero)
@@ -143,29 +122,15 @@ public final class JourneyListViewController: BaseViewController {
     }
     
     public override func configureLayout() {
-        self.view.addSubview(self.titleStack)
-        self.titleStack.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            self.titleStack.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
-            self.titleStack.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor),
-            self.titleStack.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor)
-        ])
-        
-        [
-            self.titleLabel,
-            self.subtitleLabel
-        ].forEach {
-            self.titleStack.addArrangedSubview($0)
-        }
-        
         self.view.addSubview(self.collectionView)
         self.collectionView.translatesAutoresizingMaskIntoConstraints = false
+        let bottomAnchor = self.collectionView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor)
+        bottomAnchor.priority = .defaultLow
         NSLayoutConstraint.activate([
-            self.collectionView.topAnchor.constraint(equalTo: self.titleStack.bottomAnchor,
-                                                     constant: Metric.collectionViewVerticalInset),
+            self.collectionView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
             self.collectionView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor,
                                                          constant: Metric.collectionViewHorizontalInset),
-            self.collectionView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor),
+            bottomAnchor,
             self.collectionView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor,
                                                           constant: -Metric.collectionViewHorizontalInset)
         ])
@@ -178,9 +143,19 @@ public final class JourneyListViewController: BaseViewController {
 extension JourneyListViewController: UICollectionViewDelegate {
     
     private func configureCollectionView() {
+        let configuration = UICollectionViewCompositionalLayoutConfiguration()
+        
+        let headerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
+                                                heightDimension: .estimated(JourneyListHeaderView.estimatedHight))
+        let header = NSCollectionLayoutBoundarySupplementaryItem(layoutSize: headerSize,
+                                                                 elementKind: UICollectionView.elementKindSectionHeader,
+                                                                 alignment: .top)
+        header.pinToVisibleBounds = true
+        configuration.boundarySupplementaryItems = [header]
+        
         let layout = UICollectionViewCompositionalLayout(sectionProvider: { _, _ in
             return self.configureSection()
-        })
+        }, configuration: configuration)
         
         self.collectionView.setCollectionViewLayout(layout, animated: false)
         self.dataSource = self.configureDataSource()
@@ -252,6 +227,11 @@ extension JourneyListViewController: UICollectionViewDelegate {
                 }
             }
         }
+        
+        let headerRegistration = JourneyListHeaderRegistration(elementKind: UICollectionView.elementKindSectionHeader,
+                                                               handler: { header, _, indexPath in
+            
+        })
       
         let dataSource = JourneyListDataSource(collectionView: self.collectionView,
                                                cellProvider: { collectionView, indexPath, item in
@@ -259,6 +239,11 @@ extension JourneyListViewController: UICollectionViewDelegate {
                                                                 for: indexPath,
                                                                 item: item)
         })
+        
+        dataSource.supplementaryViewProvider = { collectionView, _, indexPath in
+            return collectionView.dequeueConfiguredReusableSupplementary(using: headerRegistration,
+                                                                         for: indexPath)
+        }
         
         return dataSource
     }

--- a/iOS/Features/JourneyList/Sources/JourneyList/Presentation/VIew/JourneyListHeaderView.swift
+++ b/iOS/Features/JourneyList/Sources/JourneyList/Presentation/VIew/JourneyListHeaderView.swift
@@ -1,0 +1,107 @@
+//
+//  JourneyListHeaderView.swift
+//  JourneyList
+//
+//  Created by 이창준 on 2023.12.02.
+//
+
+import UIKit
+
+import MSDesignSystem
+
+public final class JourneyListHeaderView: UICollectionReusableView {
+    
+    // MARK: - Constants
+    
+    static let estimatedHight: CGFloat = 46.0 + Metric.verticalInset
+    
+    private enum Typo {
+        
+        static let title: String = "지난 여정"
+        static func subtitle(numberOfJourneys: Int) -> String {
+            return "현재 위치에 \(numberOfJourneys)개의 여정이 있습니다."
+        }
+        
+    }
+    
+    private enum Metric {
+        
+        static let titleStackSpacing: CGFloat = 4.0
+        static let horizontalInset: CGFloat = 16.0
+        static let verticalInset: CGFloat = 24.0
+        
+    }
+    
+    // MARK: - UI Components
+    
+    private let titleStack: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.spacing = Metric.titleStackSpacing
+        stackView.distribution = .fillProportionally
+        return stackView
+    }()
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .msFont(.headerTitle)
+        label.textColor = .msColor(.primaryTypo)
+        label.text = Typo.title
+        return label
+    }()
+    
+    private let subtitleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .msFont(.caption)
+        label.textColor = .msColor(.secondaryTypo)
+        label.text = Typo.subtitle(numberOfJourneys: 0)
+        return label
+    }()
+    
+    // MARK: - Initializer
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.configureStyles()
+        self.configureLayout()
+    }
+    
+    public required init?(coder: NSCoder) {
+        fatalError("MusicSpot은 code-based로만 작업 중입니다.")
+    }
+    
+}
+
+// MARK: - UI Configuration
+
+private extension JourneyListHeaderView {
+    
+    func configureStyles() {
+        self.backgroundColor = .msColor(.primaryBackground)
+    }
+    
+    func configureLayout() {
+        self.addSubview(self.titleStack)
+        
+        [
+            self.titleLabel,
+            self.subtitleLabel
+        ].forEach {
+            self.titleStack.addArrangedSubview($0)
+        }
+        self.titleStack.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            self.heightAnchor.constraint(equalToConstant: JourneyListHeaderView.estimatedHight),
+            
+            self.titleStack.topAnchor.constraint(equalTo: self.topAnchor),
+            self.titleStack.leadingAnchor.constraint(equalTo: self.leadingAnchor,
+                                                     constant: Metric.horizontalInset),
+            self.titleStack.bottomAnchor.constraint(lessThanOrEqualTo: self.bottomAnchor,
+                                                    constant: -Metric.verticalInset),
+            self.titleStack.trailingAnchor.constraint(equalTo: self.trailingAnchor,
+                                                      constant: Metric.horizontalInset)
+        ])
+    }
+    
+}

--- a/iOS/Features/JourneyList/Sources/JourneyList/Presentation/VIew/MSCollectionView.swift
+++ b/iOS/Features/JourneyList/Sources/JourneyList/Presentation/VIew/MSCollectionView.swift
@@ -1,0 +1,23 @@
+//
+//  MSCollectionView.swift
+//  JourneyList
+//
+//  Created by 이창준 on 2023.12.02.
+//
+
+import UIKit
+
+final class MSCollectionView: UICollectionView {
+    
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        let supplementaryViews = self.visibleSupplementaryViews(ofKind: UICollectionView.elementKindSectionHeader)
+        for supplementaryView in supplementaryViews {
+            if supplementaryView.frame.contains(point) {
+                return nil
+            }
+        }
+        
+        return super.hitTest(point, with: event)
+    }
+    
+}

--- a/iOS/MSFoundation/Sources/MSLogger/MSLogCategory.swift
+++ b/iOS/MSFoundation/Sources/MSLogger/MSLogCategory.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 public enum MSLogCategory: String {
+    case ui = "UI"
     case network
     case userDefaults
     case dataCore

--- a/iOS/MSUIKit/Package.swift
+++ b/iOS/MSUIKit/Package.swift
@@ -8,8 +8,24 @@ import PackageDescription
 extension String {
     
     static let package = "MSUIKit"
-    static let designSystem = "MSDesignSystem"
-    static let uiKit = "MSUIKit"
+    
+    var fromRootPath: String {
+        return "../" + self
+    }
+    
+}
+
+private enum Target {
+    
+    static let msDesignSystem = "MSDesignSystem"
+    static let msUIKit = "MSUIKit"
+    
+}
+
+private enum Dependency {
+    
+    static let msFoundation = "MSFoundation"
+    static let msLogger = "MSLogger"
     
 }
 
@@ -21,20 +37,26 @@ let package = Package(
         .iOS(.v15)
     ],
     products: [
-        .library(name: .designSystem,
-                 type: .static,
-                 targets: [.designSystem]),
-        .library(name: .uiKit,
-                 targets: [.uiKit])
+        .library(name: Target.msDesignSystem,
+                 targets: [Target.msDesignSystem]),
+        .library(name: Target.msUIKit,
+                 targets: [Target.msUIKit])
+    ],
+    dependencies: [
+        .package(name: Dependency.msFoundation,
+                 path: Dependency.msFoundation.fromRootPath)
     ],
     targets: [
-        // Codes
-        .target(name: .designSystem,
+        .target(name: Target.msDesignSystem,
                 resources: [
-                    .process("../\(String.designSystem)/Resources")
+                    .process("\(Target.msDesignSystem.fromRootPath)/Resources")
                 ]),
-        .target(name: .uiKit,
-                dependencies: ["MSDesignSystem"])
+        .target(name: Target.msUIKit,
+                dependencies: [
+                    .target(name: Target.msDesignSystem),
+                    .product(name: Dependency.msLogger,
+                             package: Dependency.msFoundation)
+                ])
     ],
     swiftLanguageVersions: [.v5]
 )

--- a/iOS/MSUIKit/Sources/MSUIKit/MSBottomSheetViewController.swift
+++ b/iOS/MSUIKit/Sources/MSUIKit/MSBottomSheetViewController.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 import MSDesignSystem
+import MSLogger
 
 open class MSBottomSheetViewController<Content: UIViewController, BottomSheet: UIViewController>
 : UIViewController, UIGestureRecognizerDelegate {
@@ -38,7 +39,7 @@ open class MSBottomSheetViewController<Content: UIViewController, BottomSheet: U
     
     // MARK: - State
     
-    public enum State {
+    public enum State: String {
         case full
         case detented
         case minimized
@@ -69,8 +70,11 @@ open class MSBottomSheetViewController<Content: UIViewController, BottomSheet: U
     // MARK: - Properties
     
     private let configuration: BottomSheetConfiguration
-    var state: State = .minimized
     private let gestureVelocity: CGFloat = 750.0
+    
+    public var state: State = .minimized {
+        willSet { self.stateDidChanged(newValue) }
+    }
     
     // MARK: - Initializer
     
@@ -92,7 +96,11 @@ open class MSBottomSheetViewController<Content: UIViewController, BottomSheet: U
     
     // MARK: - Functions
     
-    public func presentFullBottomSheet(animated: Bool = true) {
+    public func stateDidChanged(_ state: State) {
+        MSLogger.make(category: .ui).log("Bottom Sheet 상태가 \(state.rawValue)로 업데이트 되었습니다.")
+    }
+    
+    private func presentFullBottomSheet(animated: Bool = true) {
         self.topConstraints?.constant = -self.configuration.fullHeight
         
         if animated {
@@ -107,7 +115,7 @@ open class MSBottomSheetViewController<Content: UIViewController, BottomSheet: U
         }
     }
     
-    public func presentDetentedBottomSheet(animated: Bool = true) {
+    private func presentDetentedBottomSheet(animated: Bool = true) {
         self.topConstraints?.constant = -self.configuration.detentHeight
         
         if animated {
@@ -126,7 +134,7 @@ open class MSBottomSheetViewController<Content: UIViewController, BottomSheet: U
         }
     }
     
-    public func dismissBottomSheet(animated: Bool = true) {
+    private func dismissBottomSheet(animated: Bool = true) {
         self.topConstraints?.constant = -self.configuration.minimizedHeight
         
         if animated {

--- a/iOS/MSUIKit/Sources/MSUIKit/MSBottomSheetViewController.swift
+++ b/iOS/MSUIKit/Sources/MSUIKit/MSBottomSheetViewController.swift
@@ -85,8 +85,8 @@ open class MSBottomSheetViewController<Content: UIViewController, BottomSheet: U
         self.bottomSheetViewController = bottomSheetViewController
         self.configuration = configuration
         super.init(nibName: nil, bundle: nil)
-        self.configureLayout()
         self.configureStyle()
+        self.configureLayout()
         self.configureGesture()
     }
     
@@ -98,6 +98,10 @@ open class MSBottomSheetViewController<Content: UIViewController, BottomSheet: U
     
     public func stateDidChanged(_ state: State) {
         MSLogger.make(category: .ui).log("Bottom Sheet 상태가 \(state.rawValue)로 업데이트 되었습니다.")
+        
+        if case .full = state {
+            self.resizeIndicator.isHidden = true
+        }
     }
     
     private func presentFullBottomSheet(animated: Bool = true) {
@@ -172,6 +176,8 @@ open class MSBottomSheetViewController<Content: UIViewController, BottomSheet: U
     }
     
     private func handlePanChanged(translation: CGPoint) {
+        self.resizeIndicator.isHidden = false
+        
         switch self.state {
         case .full:
             guard translation.y > 0 else { return }
@@ -206,7 +212,7 @@ open class MSBottomSheetViewController<Content: UIViewController, BottomSheet: U
                 self.presentFullBottomSheet()
             }
         case .detented:
-            if yTransMagnitude >= self.configuration.fullDetentDiff / 2 || velocity.y < -self.gestureVelocity {
+            if translation.y <= -self.configuration.fullDetentDiff / 2 || velocity.y < -self.gestureVelocity {
                 self.presentFullBottomSheet()
             } else if translation.y >= self.configuration.detentMinimizedDiff / 2 || velocity.y > self.gestureVelocity {
                 self.dismissBottomSheet()
@@ -233,12 +239,6 @@ open class MSBottomSheetViewController<Content: UIViewController, BottomSheet: U
         }
     }
     
-    public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer,
-                                  shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
-    ) -> Bool {
-        return false
-    }
-    
 }
 
 // MARK: - UI Configuration
@@ -259,25 +259,25 @@ private extension MSBottomSheetViewController {
         
         self.contentViewController.view.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            self.contentViewController.view.leftAnchor
-                .constraint(equalTo: self.view.leftAnchor),
-            self.contentViewController.view.rightAnchor
-                .constraint(equalTo: self.view.rightAnchor),
             self.contentViewController.view.topAnchor
                 .constraint(equalTo: self.view.topAnchor),
+            self.contentViewController.view.leadingAnchor
+                .constraint(equalTo: self.view.leadingAnchor),
             self.contentViewController.view.bottomAnchor
-                .constraint(equalTo: self.view.bottomAnchor)
+                .constraint(equalTo: self.view.bottomAnchor),
+            self.contentViewController.view.trailingAnchor
+                .constraint(equalTo: self.view.trailingAnchor)
         ])
         self.contentViewController.didMove(toParent: self)
         
         self.bottomSheetViewController.view.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            self.bottomSheetViewController.view.heightAnchor
-                .constraint(equalToConstant: self.configuration.fullHeight),
-            self.bottomSheetViewController.view.leftAnchor
-                .constraint(equalTo: self.view.leftAnchor),
-            self.bottomSheetViewController.view.rightAnchor
-                .constraint(equalTo: self.view.rightAnchor)
+            self.bottomSheetViewController.view.leadingAnchor
+                .constraint(equalTo: self.view.leadingAnchor),
+            self.bottomSheetViewController.view.bottomAnchor
+                .constraint(equalTo: self.view.bottomAnchor),
+            self.bottomSheetViewController.view.trailingAnchor
+                .constraint(equalTo: self.view.trailingAnchor)
         ])
         self.topConstraints = self.bottomSheetViewController.view.topAnchor
             .constraint(equalTo: self.view.bottomAnchor,
@@ -292,7 +292,7 @@ private extension MSBottomSheetViewController {
             self.resizeIndicator.heightAnchor.constraint(equalToConstant: 5.0),
             self.resizeIndicator.centerXAnchor.constraint(equalTo: self.bottomSheetViewController.view.centerXAnchor),
             self.resizeIndicator.topAnchor.constraint(equalTo: self.bottomSheetViewController.view.topAnchor,
-                                                      constant: 5.0)
+                                                      constant: 6.0)
         ])
     }
     

--- a/iOS/MSUIKit/Sources/MSUIKit/MSBottomSheetViewController/BottomSheetConfiguration.swift
+++ b/iOS/MSUIKit/Sources/MSUIKit/MSBottomSheetViewController/BottomSheetConfiguration.swift
@@ -1,0 +1,73 @@
+//
+//  BottomSheetConfiguration.swift
+//  MSUIKit
+//
+//  Created by 이창준 on 2023.12.01.
+//
+
+import CoreGraphics
+import Foundation
+
+extension MSBottomSheetViewController {
+    
+    public struct Configuration {
+        
+        public enum Dimension {
+            case fractional(CGFloat)
+            case absolute(CGFloat)
+        }
+        
+        // MARK: - Properties
+        
+        var standardMetric: CGFloat?
+        
+        let fullDimension: Dimension
+        let detentDimension: Dimension
+        let minimizedDimension: Dimension
+        
+        var fullHeight: CGFloat {
+            return self.calculateHeight(for: self.fullDimension)
+        }
+        
+        var detentHeight: CGFloat {
+            return self.calculateHeight(for: self.detentDimension)
+        }
+        
+        var minimizedHeight: CGFloat {
+            return self.calculateHeight(for: self.minimizedDimension)
+        }
+        
+        var fullDetentDiff: CGFloat {
+            return self.fullHeight - self.detentHeight
+        }
+        
+        var detentMinimizedDiff: CGFloat {
+            return self.detentHeight - self.minimizedHeight
+        }
+        
+        // MARK: - Initializer
+        
+        public init(fullDimension: Dimension,
+                    detentDimension: Dimension,
+                    minimizedDimension: Dimension) {
+            self.fullDimension = fullDimension
+            self.detentDimension = detentDimension
+            self.minimizedDimension = minimizedDimension
+        }
+        
+        // MARK: - Helpers
+        
+        private func calculateHeight(for dimension: Dimension) -> CGFloat {
+            guard let standardMetric = standardMetric else { return .zero }
+            
+            switch dimension {
+            case .fractional(let fractionalDimension):
+                return standardMetric * fractionalDimension
+            case .absolute(let absoluteDimension):
+                return absoluteDimension
+            }
+        }
+        
+    }
+    
+}

--- a/iOS/MusicSpot/MusicSpot/MSCoordinator/HomeCoordinator.swift
+++ b/iOS/MusicSpot/MusicSpot/MSCoordinator/HomeCoordinator.swift
@@ -48,12 +48,11 @@ final class HomeCoordinator: Coordinator {
         journeyListViewController.delegate = self
         
         // Bottom Sheet
-        let configuration = HomeBottomSheetViewController.BottomSheetConfiguration(fullHeight: 852.0,
-                                                                                   detentHeight: 425.0,
-                                                                                   minimizedHeight: 150.0)
         let homeBottomSheetVC = HomeBottomSheetViewController(contentViewController: navigateMapViewController,
-                                                              bottomSheetViewController: journeyListViewController,
-                                                              configuration: configuration)
+                                                              bottomSheetViewController: journeyListViewController)
+        homeBottomSheetVC.configuration = MSBottomSheetViewController.Configuration(fullDimension: .fractional(1.0),
+                                                                                    detentDimension: .fractional(0.4),
+                                                                                    minimizedDimension: .absolute(100.0))
         homeBottomSheetVC.delegate = self
         self.navigationController.pushViewController(homeBottomSheetVC, animated: true)
     }

--- a/iOS/MusicSpot/MusicSpot/MSCoordinator/HomeCoordinator.swift
+++ b/iOS/MusicSpot/MusicSpot/MSCoordinator/HomeCoordinator.swift
@@ -50,7 +50,7 @@ final class HomeCoordinator: Coordinator {
         // Bottom Sheet
         let configuration = HomeBottomSheetViewController.BottomSheetConfiguration(fullHeight: 852.0,
                                                                                    detentHeight: 425.0,
-                                                                                   minimizedHeight: 100.0)
+                                                                                   minimizedHeight: 150.0)
         let homeBottomSheetVC = HomeBottomSheetViewController(contentViewController: navigateMapViewController,
                                                               bottomSheetViewController: journeyListViewController,
                                                               configuration: configuration)


### PR DESCRIPTION
## ❗ 배경
> 작업 배경에 대한 설명을 작성합니다.
> Issue에 대한 링크를 첨부합니다.

- Close #169 

## 🔧 작업 내역
> 작업한 내용들을 나열합니다.
> 간결하게 리스트 업하고, 자세한 설명은 아래 리뷰 노트에서 합니다.

- MSBottomSheetViewController 크기 설정 방식 수정
- BottomListViewController 스택뷰 UI 버그 수정

## 🧪 테스트 방법
> 동작을 테스트할 수 있는 방법을 설명합니다.
> 앱 실행 방법일 수 있고, 유닛 테스트 실행 방법일 수 있습니다.

- JourneyListDemo 혹은 MusicSpot 앱 실행

## 📝 리뷰 노트
> 작업 내역에 대한 자세한 설명을 작성합니다.

### MSBottomSheetViewController

```swift
let homeBottomSheetVC = HomeBottomSheetViewController(contentViewController: navigateMapViewController,
                                                      bottomSheetViewController: journeyListViewController,
                                                      configuration: .init(fullHeight: 933.0,
                                                                           detentHight: 400.0,
                                                                           minimizedHeight: 120.0))
```

원래 이런 방식으로 고정값으로 생성자에서 값을 줬지만

```swift
let homeBottomSheetVC = HomeBottomSheetViewController(contentViewController: navigateMapViewController,
                                                      bottomSheetViewController: journeyListViewController)
homeBottomSheetVC.configuration = MSBottomSheetViewController.Configuration(fullDimension: .fractional(1.0),
                                                                            detentDimension: .fractional(0.4),
                                                                            minimizedDimension: .absolute(100.0))
```

이렇게 `configuration` 프로퍼티에 따로 지정해주는 방식으로 수정했습니다.

또한 크기를 주는 방식을
`.fractional(CGFloat)`의 비율로 지정하는 방식과
`.absolute(CGFloat)`로 고정 수치로 지정하는 방식
두 가지로 나누어 좀 더 유연한 설정이 가능하도록 변경했습니다.

### JourneyListViewController

이전 버전에서는 기기의 사이즈에 따라 헤더의 `titleStack`이 쪼그라드는 문제가 있었습니다.
때문에 `UIStackView`를 따로 사용하는 것이 아니라
`UICollectionView`의 헤더로 설정해 레이아웃 문제가 애초에 일어나지 않도록 수정했습니다.

하지만 이 방식으로 설정했더니 `HeaderView`가 `UICollectionView`에 속하게 되어 `MSBottomSheetViewController`의 `panGesture`를 무시하게 되는 문제가 발생했습니다.
때문에 `supplementaryView`의 `hitTest`를 무시하는 `MSCollectionView`를 추가해 사용했습니다.

```swift
final class MSCollectionView: UICollectionView {
    
    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
        let supplementaryViews = self.visibleSupplementaryViews(ofKind: UICollectionView.elementKindSectionHeader)
        for supplementaryView in supplementaryViews {
            if supplementaryView.frame.contains(point) {
                return nil
            }
        }
        
        return super.hitTest(point, with: event)
    }
    
}
```

## 📸 스크린샷
> 작업한 내용에 대한 스크린샷, 영상 등을 첨부합니다.

| iPhone 11 Pro | iPhone 15 Pro |
| :-: | :-: |
| <img src="https://github.com/boostcampwm2023/iOS01-MusicSpot/assets/138548400/06356371-f645-44d3-8884-9bb6226bdff9" width="300"> | <img src="https://github.com/boostcampwm2023/iOS01-MusicSpot/assets/138548400/798d5d1e-5903-430f-b1d0-b5144b1157c9" width="300"> |
