### PR TITLE
[iOS] SpotScene 화면 레이아웃 수정 + 뒤로가기 추가

### DIFF
--- a/iOS/Features/Spot/Sources/Spot/Presentation/SpotViewController.swift
+++ b/iOS/Features/Spot/Sources/Spot/Presentation/SpotViewController.swift
@@ -50,13 +50,19 @@ public final class SpotViewController: UIViewController, UINavigationControllerD
             static let trailingInset: CGFloat = 30.0
             static let radius: CGFloat = width / 2
         }
+        
+        // back button
+        enum BackButton {
+            static let height: CGFloat = 35.0
+            static let width: CGFloat = 35.0
+            static let inset: CGFloat = 10.0
+        }
     }
     
     // MARK: - Properties
     
     public weak var navigationDelegate: SpotNavigationDelegate?
     private let spotViewModel = SpotViewModel()
-    
     private let spotSaveViewController = SpotSaveViewController()
     
     // MARK: - Properties: Networking
@@ -79,12 +85,7 @@ public final class SpotViewController: UIViewController, UINavigationControllerD
     
     // MARK: - UI Components
     
-    private let navigationBarBackgroundView: UIView = {
-        let view = UIView()
-        view.backgroundColor = .msColor(.componentBackground)
-        view.isUserInteractionEnabled = false
-        return view
-    }()
+    private let backButton = UIButton()
     private let cameraView = CameraView()
     private let shotButton = UIButton()
     private let galleryButton = UIButton()
@@ -95,11 +96,6 @@ public final class SpotViewController: UIViewController, UINavigationControllerD
     public override func viewDidLoad() {
         super.viewDidLoad()
         self.configure()
-    }
-    
-    public override func viewIsAppearing(_ animated: Bool) {
-        super.viewIsAppearing(animated)
-        self.navigationController?.isNavigationBarHidden = false
     }
     
     public override func viewDidAppear(_ animated: Bool) {
@@ -128,7 +124,7 @@ private extension SpotViewController {
             self.shotButton,
             self.galleryButton,
             self.swapButton,
-            self.navigationBarBackgroundView
+            self.backButton
         ].forEach {
             self.view.addSubview($0)
             $0.translatesAutoresizingMaskIntoConstraints = false
@@ -143,9 +139,9 @@ private extension SpotViewController {
     
     func configureCameraViewLayout() {
         NSLayoutConstraint.activate([
-            self.cameraView.topAnchor.constraint(equalTo: self.view.topAnchor),
-            self.cameraView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
-            self.cameraView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor,
+            self.cameraView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
+            self.cameraView.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor),
+            self.cameraView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor,
                                                     constant: -Metric.CameraView.bottomInset),
             self.cameraView.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor)
         ])
@@ -188,10 +184,13 @@ private extension SpotViewController {
     
     func configureNavigationBarBackgroundViewLayout() {
         NSLayoutConstraint.activate([
-            self.navigationBarBackgroundView.topAnchor.constraint(equalTo: self.view.topAnchor),
-            self.navigationBarBackgroundView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
-            self.navigationBarBackgroundView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
-            self.navigationBarBackgroundView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor)
+            self.backButton.heightAnchor.constraint(equalToConstant: Metric.BackButton.height),
+            self.backButton.widthAnchor.constraint(equalToConstant: Metric.BackButton.width),
+            
+            self.backButton.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor,
+                                                 constant: Metric.BackButton.inset),
+            self.backButton.leadingAnchor.constraint(equalTo: self.view.leadingAnchor,
+                                                     constant: Metric.BackButton.inset)
         ])
     }
     
@@ -219,6 +218,12 @@ private extension SpotViewController {
         self.swapButton.setImage(UIImage(systemName: "arrow.triangle.2.circlepath"), for: .normal)
         self.swapButton.tintColor = .white
         
+        self.backButton.backgroundColor = .darkGray
+        self.backButton.alpha = 0.5
+        self.backButton.layer.cornerRadius = Metric.SwapButton.radius
+        self.backButton.setImage(UIImage(systemName: "xmark"), for: .normal)
+        self.backButton.tintColor = .white
+        
         self.spotSaveViewController.modalPresentationStyle = .fullScreen
     }
     
@@ -232,7 +237,10 @@ private extension SpotViewController {
         self.configureCameraSetting()
         self.configureShotButtonAction()
         self.configureSwapButtonAction()
+        self.configureBackButtonAction()
         self.configureGalleryButtonAction()
+        
+//        self.configure
     }
     
     func configureShotButtonAction() {
@@ -256,6 +264,13 @@ private extension SpotViewController {
         self.galleryButton.addAction(galleryButtonAction, for: .touchUpInside)
     }
     
+    func configureBackButtonAction() {
+        let backButtonAction = UIAction(handler: { _ in
+            self.backButtonTapped()
+        })
+        self.backButton.addAction(backButtonAction, for: .touchUpInside)
+    }
+    
     private func configureCameraSetting() {
         self.spotViewModel.preset(screen: cameraView)
     }
@@ -277,6 +292,11 @@ private extension SpotViewController {
     func galleryButtonTapped() {
         self.navigationDelegate?.presentPhotos(from: self)
     }
+    
+    func backButtonTapped() {
+        self.navigationDelegate?.popToHome()
+    }
+    
 }
 
 // MARK: - Configuration: Delegate

--- a/iOS/Features/Spot/Sources/Spot/Presentation/SpotViewController.swift
+++ b/iOS/Features/Spot/Sources/Spot/Presentation/SpotViewController.swift
@@ -83,6 +83,10 @@ public final class SpotViewController: UIViewController, UINavigationControllerD
         }
     }
     
+    // MARK: - Properties: Gesture
+    
+    var initialTouchPoint = CGPoint(x: 0, y: 0)
+    
     // MARK: - UI Components
     
     private let backButton = UIButton()
@@ -240,7 +244,7 @@ private extension SpotViewController {
         self.configureBackButtonAction()
         self.configureGalleryButtonAction()
         
-//        self.configure
+        self.configureUpToDownSwipeGesture()
     }
     
     func configureShotButtonAction() {
@@ -271,7 +275,35 @@ private extension SpotViewController {
         self.backButton.addAction(backButtonAction, for: .touchUpInside)
     }
     
-    private func configureCameraSetting() {
+    func configureUpToDownSwipeGesture() {
+        let panGesture = UIPanGestureRecognizer(target: self, action: #selector(panGestureDismiss(_:)))
+            self.view.addGestureRecognizer(panGesture)
+    }
+
+    @objc
+    func panGestureDismiss(_ sender: UIPanGestureRecognizer) {
+        let touchPoint = sender.location(in: self.view.window)
+        
+        switch sender.state {
+        case .began:
+            initialTouchPoint = touchPoint
+        case .changed:
+            if touchPoint.y - initialTouchPoint.y > 0 {
+                self.view.frame = CGRect(x: 0, y: touchPoint.y - initialTouchPoint.y, width: self.view.frame.width, height: self.view.frame.height)
+            }
+        case .ended, .cancelled:
+            if touchPoint.y - initialTouchPoint.y > 200 {
+                //                self.dismiss(animated: true, completion: nil)
+                self.navigationDelegate?.popToHome()
+            }
+        default:
+            UIView.animate(withDuration: 0.3) {
+                self.view.frame = CGRect(x: 0, y: 0, width: self.view.frame.width, height: self.view.frame.height)
+            }
+        }
+    }
+    
+    func configureCameraSetting() {
         self.spotViewModel.preset(screen: cameraView)
     }
     

--- a/iOS/MusicSpot/MusicSpot/MSCoordinator/SpotCoordinator.swift
+++ b/iOS/MusicSpot/MusicSpot/MSCoordinator/SpotCoordinator.swift
@@ -22,6 +22,7 @@ final class SpotCoordinator: Coordinator {
     
     func start() {
         let spotViewController = SpotViewController()
+        self.navigationController.modalTransitionStyle = .coverVertical
         self.navigationController.pushViewController(spotViewController, animated: true)
         spotViewController.navigationDelegate = self
     }

--- a/iOS/MusicSpot/MusicSpot/MSCoordinator/SpotCoordinator.swift
+++ b/iOS/MusicSpot/MusicSpot/MSCoordinator/SpotCoordinator.swift
@@ -10,20 +10,13 @@ import UIKit
 import Spot
 
 final class SpotCoordinator: Coordinator {
-    
+
     // MARK: - Properties
     
     var navigationController: UINavigationController
-    
     var childCoordinators: [Coordinator] = []
     
     weak var delegate: HomeCoordinatorDelegate?
-    
-    // MARK: - Initializer
-    
-    init(navigationController: UINavigationController) {
-        self.navigationController = navigationController
-    }
     
     // MARK: - Functions
     
@@ -31,6 +24,12 @@ final class SpotCoordinator: Coordinator {
         let spotViewController = SpotViewController()
         self.navigationController.pushViewController(spotViewController, animated: true)
         spotViewController.navigationDelegate = self
+    }
+    
+    // MARK: - Initializer
+    
+    init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
     }
     
 }


### PR DESCRIPTION
## ❗ 배경
> 작업 배경에 대한 설명을 작성합니다.
> Issue에 대한 링크를 첨부합니다.
#198 
#199

## 🔧 작업 내역
> 작업한 내용들을 나열합니다.
> 간결하게 리스트 업하고, 자세한 설명은 아래 리뷰 노트에서 합니다.
- [x] Spot 아래 제스처로 뒤로가기 기능 추가
- [x] Spot 뒤로가기 버튼 추가 
- [x] Spot 화면 레이아웃 수정

## 🧪 테스트 방법
> 동작을 테스트할 수 있는 방법을 설명합니다.
> 앱 실행 방법일 수 있고, 유닛 테스트 실행 방법일 수 있습니다.

## 📝 리뷰 노트
> 작업 내역에 대한 자세한 설명을 작성합니다.

## 📸 스크린샷
> 작업한 내용에 대한 스크린샷, 영상 등을 첨부합니다.
![RPReplay_Final1701782735](https://github.com/boostcampwm2023/iOS01-MusicSpot/assets/111111595/86b38890-c152-4728-8c97-2f483586f7f5)<img src="https://github.com/boostcampwm2023/iOS01-MusicSpot/assets/111111595/3b92d303-7b3c-439e-b97f-17ca9a059f8c" width="256"/>
- 제스처로 뒤로가기와 뒤로가기 버튼



