### PR TITLE
[iOS] 음악 관련 로직 추가

### DIFF
--- a/iOS/Features/SaveJourney/Sources/SaveJourney/Presentation/ButtonStateFactor.swift
+++ b/iOS/Features/SaveJourney/Sources/SaveJourney/Presentation/ButtonStateFactor.swift
@@ -1,0 +1,15 @@
+//
+//  ButtonStateFactor.swift
+//  SaveJourney
+//
+//  Created by 이창준 on 2023.12.09.
+//
+
+import Foundation
+
+final class ButtonStateFactor: ObservableObject {
+    
+    @Published var canBecomeSubscriber: Bool = false
+    @Published var isMusicPlaying: Bool = false
+    
+}

--- a/iOS/Features/SaveJourney/Sources/SaveJourney/Presentation/SaveJourneySection.swift
+++ b/iOS/Features/SaveJourney/Sources/SaveJourney/Presentation/SaveJourneySection.swift
@@ -11,9 +11,10 @@ import MSDomain
 
 // MARK: - Section
 
-enum SaveJourneySection {
+enum SaveJourneySection: Hashable {
     case music
     case spot
+    case empty
     
     var itemSize: NSCollectionLayoutSize {
         switch self {
@@ -23,6 +24,9 @@ enum SaveJourneySection {
         case .spot:
             return NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.5),
                                           heightDimension: .fractionalWidth(0.5))
+        case .empty:
+            return NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
+                                          heightDimension: .fractionalHeight(1.0))
         }
     }
     
@@ -34,6 +38,9 @@ enum SaveJourneySection {
         case .spot:
             return NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
                                           heightDimension: .fractionalWidth(0.5))
+        case .empty:
+            return NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
+                                          heightDimension: .fractionalWidth(1.0))
         }
     }
     
@@ -45,5 +52,6 @@ enum SaveJourneyItem: Hashable {
     
     case music(Music)
     case spot(Spot)
+    case empty
     
 }

--- a/iOS/Features/SaveJourney/Sources/SaveJourney/Presentation/SaveJourneyViewController.swift
+++ b/iOS/Features/SaveJourney/Sources/SaveJourney/Presentation/SaveJourneyViewController.swift
@@ -133,6 +133,11 @@ public final class SaveJourneyViewController: UIViewController {
         self.navigationController?.isNavigationBarHidden = false
     }
     
+    public override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        self.musicPlayer.pause()
+    }
+    
     // MARK: - Combine Binding
     
     private func bind() {

--- a/iOS/Features/SaveJourney/Sources/SaveJourney/Presentation/SaveJourneyViewModel.swift
+++ b/iOS/Features/SaveJourney/Sources/SaveJourney/Presentation/SaveJourneyViewModel.swift
@@ -98,7 +98,6 @@ private extension SaveJourneyViewModel {
                 #endif
                 self.trigger(.endJourneyDidSucceed(journey))
             case .failure(let error):
-                print(error)
                 #if DEBUG
                 MSLogger.make(category: .saveJourney).error("\(error)")
                 #endif

--- a/iOS/Features/SaveJourney/Sources/SaveJourney/Presentation/SaveJourneyViewModel.swift
+++ b/iOS/Features/SaveJourney/Sources/SaveJourney/Presentation/SaveJourneyViewModel.swift
@@ -6,7 +6,7 @@
 //
 
 import Combine
-import MediaPlayer
+import Foundation
 import MusicKit
 
 import MSData
@@ -17,16 +17,18 @@ public final class SaveJourneyViewModel {
     
     public enum Action {
         case viewNeedsLoaded
-        case mediaControlButtonDidTap
+        case musicControlButtonDidTap
         case titleDidConfirmed(String)
         case endJourneyDidSucceed(String)
     }
     
     public struct State {
+        /// Apple Music 권한 상태
+        var musicAuthorizatonStatus = CurrentValueSubject<MusicAuthorization.Status, Never>(.notDetermined)
+        var buttonStateFactors = CurrentValueSubject<ButtonStateFactor, Never>(ButtonStateFactor())
+        
         var recordingJourney: CurrentValueSubject<RecordingJourney, Never>
         var selectedSong: CurrentValueSubject<Song, Never>
-        var isMusicPlaying = CurrentValueSubject<Bool, Never>(false)
-        var mediaItem = PassthroughSubject<MPMediaQuery?, Never>()
         
         var endJourneyResponse = CurrentValueSubject<String?, Never>(nil)
     }
@@ -39,21 +41,17 @@ public final class SaveJourneyViewModel {
     
     /// 완료 버튼을 누른 시점의 마지막 좌표
     private let lastCoordiante: Coordinate
-    /// 음악 검색 시 선택한 음악의 IndexPath
-    private let selectedIndex: IndexPath
     
     // MARK: - Initializer
     
     public init(recordingJourney: RecordingJourney,
                 lastCoordinate: Coordinate,
                 selectedSong: Song,
-                selectedIndex: IndexPath,
                 journeyRepository: JourneyRepository) {
         self.journeyRepository = journeyRepository
         self.state = State(recordingJourney: CurrentValueSubject<RecordingJourney, Never>(recordingJourney),
                            selectedSong: CurrentValueSubject<Song, Never>(selectedSong))
         self.lastCoordiante = lastCoordinate
-        self.selectedIndex = selectedIndex
     }
     
     // MARK: - Functions
@@ -61,11 +59,27 @@ public final class SaveJourneyViewModel {
     func trigger(_ action: Action) {
         switch action {
         case .viewNeedsLoaded:
-            let mediaItem = self.querySong(self.state.selectedSong.value,
-                                           at: self.selectedIndex.item)
-            self.state.mediaItem.send(mediaItem)
-        case .mediaControlButtonDidTap:
-            self.state.isMusicPlaying.send(!self.state.isMusicPlaying.value)
+            Task {
+                let status = await MusicAuthorization.request()
+                #if DEBUG
+                MSLogger.make(category: .saveJourney).info("음악 권한 상태: \(status)")
+                #endif
+                self.state.musicAuthorizatonStatus.send(status)
+            }
+             
+            Task {
+                let subscription = try await MusicSubscription.current
+                #if DEBUG
+                MSLogger.make(category: .saveJourney).debug("\(subscription)")
+                #endif
+                let stateFactors = self.state.buttonStateFactors.value
+                stateFactors.canBecomeSubscriber = subscription.canBecomeSubscriber
+                self.state.buttonStateFactors.send(stateFactors)
+            }
+        case .musicControlButtonDidTap:
+            let stateFactors = self.state.buttonStateFactors.value
+            stateFactors.isMusicPlaying.toggle()
+            self.state.buttonStateFactors.send(stateFactors)
         case .titleDidConfirmed(let title):
             self.endJourney(named: title)
         case .endJourneyDidSucceed(let journeyID):
@@ -103,17 +117,6 @@ private extension SaveJourneyViewModel {
                 #endif
             }
         }
-    }
-    
-    func querySong(_ song: Song, at index: Int) -> MPMediaQuery {
-        let mediaQuery = MPMediaQuery.songs()
-        
-        let titlePredicate = MPMediaPropertyPredicate(value: song.title,
-                                                      forProperty: MPMediaItemPropertyTitle)
-        
-        mediaQuery.addFilterPredicate(titlePredicate)
-        
-        return mediaQuery
     }
     
 }

--- a/iOS/Features/SaveJourney/Sources/SaveJourney/Presentation/View/MusicControlButton.swift
+++ b/iOS/Features/SaveJourney/Sources/SaveJourney/Presentation/View/MusicControlButton.swift
@@ -1,0 +1,67 @@
+//
+//  MusicControlButton.swift
+//  SaveJourney
+//
+//  Created by 이창준 on 2023.12.09.
+//
+
+import MusicKit
+import SwiftUI
+
+import MSDesignSystem
+
+struct MusicControlButton: View {
+    
+    // MARK: - State
+    
+    @ObservedObject var stateFactor: ButtonStateFactor
+    
+    @State var isShowingOffer = false
+    
+    // MARK: - Properties
+    
+    var song: Song?
+    var musicControlAction: (() -> Void)?
+    
+    var offerOptions: MusicSubscriptionOffer.Options {
+        var offerOptions = MusicSubscriptionOffer.Options()
+        offerOptions.itemID = self.song?.id
+        offerOptions.messageIdentifier = .join
+        return offerOptions
+    }
+    
+    // MARK: - View
+    
+    let haptic: UIImpactFeedbackGenerator = {
+        let haptic = UIImpactFeedbackGenerator(style: .medium)
+        haptic.prepare()
+        return haptic
+    }()
+    
+    var body: some View {
+        Button(action: self.showSubscriptionOffer) {
+            if self.stateFactor.canBecomeSubscriber {
+                Image(uiImage: .msIcon(.lock) ?? .actions)
+            } else {
+                let image: UIImage? = self.stateFactor.isMusicPlaying ? .msIcon(.pause) : .msIcon(.play)
+                Image(uiImage: image ?? .actions)
+            }
+        }
+        .frame(width: 52.0, height: 60.0, alignment: .center)
+        .musicSubscriptionOffer(isPresented: self.$isShowingOffer, options: self.offerOptions)
+        .foregroundStyle(Color(uiColor: .msColor(.secondaryButtonTypo)))
+        .background(Color(uiColor: .msColor(.secondaryButtonBackground)))
+        .cornerRadius(5.0)
+    }
+    
+    private func showSubscriptionOffer() {
+        self.haptic.impactOccurred()
+        
+        if self.stateFactor.canBecomeSubscriber {
+            self.isShowingOffer = true
+        } else {
+            self.musicControlAction?()
+        }
+    }
+    
+}

--- a/iOS/Features/SaveJourney/Sources/SaveJourney/Presentation/View/SaveJourneyMusicCell.swift
+++ b/iOS/Features/SaveJourney/Sources/SaveJourney/Presentation/View/SaveJourneyMusicCell.swift
@@ -88,7 +88,7 @@ final class SaveJourneyMusicCell: UICollectionViewCell {
         self.artistLabel.text = cellModel.artist
         
         guard let albumCoverURL = cellModel.albumCover?.url else { return }
-        self.albumArtImageView.ms.setImage(with: albumCoverURL, forKey: cellModel.title)
+        self.albumArtImageView.ms.setImage(with: albumCoverURL, forKey: cellModel.id)
     }
     
 }

--- a/iOS/Features/SaveJourney/Sources/SaveJourney/Presentation/View/SpotCell.swift
+++ b/iOS/Features/SaveJourney/Sources/SaveJourney/Presentation/View/SpotCell.swift
@@ -68,6 +68,7 @@ final class SpotCell: UICollectionViewCell {
     
     // MARK: - Functions
     
+    @MainActor
     func update(with cellModel: SpotCellModel) {
         self.locationLabel.text = cellModel.location
         self.dateLabel.text = cellModel.date.formatted(date: .abbreviated, time: .omitted)

--- a/iOS/Features/SelectSong/Sources/SelectSong/Presentation/Coordinator/SelectSongNavigationDelegate.swift
+++ b/iOS/Features/SelectSong/Sources/SelectSong/Presentation/Coordinator/SelectSongNavigationDelegate.swift
@@ -14,7 +14,6 @@ public protocol SelectSongNavigationDelegate: AnyObject {
     
     func navigateToSaveJourney(recordingJourney: RecordingJourney,
                                lastCoordinate: Coordinate,
-                               selectedSong: Song,
-                               selectedIndex: IndexPath)
+                               selectedSong: Song)
     
 }

--- a/iOS/Features/SelectSong/Sources/SelectSong/Presentation/SelectSongViewController.swift
+++ b/iOS/Features/SelectSong/Sources/SelectSong/Presentation/SelectSongViewController.swift
@@ -208,7 +208,8 @@ private extension SelectSongViewController {
     
     private func configureDataSource() -> SongListDataSource {
         let cellRegistration = SongListCellRegistration { cell, _, itemIdentifier in
-            let cellModel = SongListCellModel(title: itemIdentifier.title,
+            let cellModel = SongListCellModel(id: itemIdentifier.id.rawValue,
+                                              title: itemIdentifier.title,
                                               artist: itemIdentifier.artistName,
                                               albumArtURL: itemIdentifier.artwork?.url(width: Metric.albumCoverSize,
                                                                                        height: Metric.albumCoverSize))
@@ -240,8 +241,7 @@ extension SelectSongViewController: UICollectionViewDelegate {
         #endif
         self.navigationDelegate?.navigateToSaveJourney(recordingJourney: self.viewModel.recordingJourney,
                                                        lastCoordinate: self.viewModel.lastCoordinate,
-                                                       selectedSong: item,
-                                                       selectedIndex: indexPath)
+                                                       selectedSong: item)
     }
     
 }

--- a/iOS/Features/SelectSong/Sources/SelectSong/Presentation/SelectSongViewController.swift
+++ b/iOS/Features/SelectSong/Sources/SelectSong/Presentation/SelectSongViewController.swift
@@ -41,8 +41,6 @@ public final class SelectSongViewController: BaseViewController {
     
     public weak var navigationDelegate: SelectSongNavigationDelegate?
     
-    private let musicPlayer = ApplicationMusicPlayer.shared
-    
     private let viewModel: SelectSongViewModel
     
     private var dataSource: SongListDataSource?
@@ -70,6 +68,12 @@ public final class SelectSongViewController: BaseViewController {
         let attributedString = AttributedString(Typo.searchTextFieldPlaceholder, attributes: container)
         textField.attributedPlaceholder = NSAttributedString(attributedString)
         return textField
+    }()
+    
+    private let loadingIndicator: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView(style: .medium)
+        indicator.hidesWhenStopped = true
+        return indicator
     }()
     
     // MARK: - Initializer
@@ -111,15 +115,23 @@ public final class SelectSongViewController: BaseViewController {
     private func bind() {
         self.searchTextField.textPublisher
             .debounce(for: 0.5, scheduler: DispatchQueue.main)
-            .filter { !$0.isEmpty }
-            .sink { text in
-                self.viewModel.trigger(.searchTextFieldDidUpdate(text))
+            .sink { [weak viewModel = self.viewModel] text in
+                viewModel?.trigger(.searchTextFieldDidUpdate(text))
+            }
+            .store(in: &self.cancellables)
+        
+        self.viewModel.state.isLoading
+            .receive(on: DispatchQueue.main)
+            .sink { [weak loadingIndicator = self.loadingIndicator] isLoading in
+                isLoading ? loadingIndicator?.startAnimating() : loadingIndicator?.stopAnimating()
             }
             .store(in: &self.cancellables)
         
         self.viewModel.state.songs
             .receive(on: DispatchQueue.main)
-            .sink { songs in
+            .sink { [weak self] songs in
+                guard let self = self else { return }
+                
                 var snapshot = SongListSnapshot()
                 snapshot.appendSections([.zero])
                 snapshot.appendItems(songs, toSection: .zero)
@@ -154,6 +166,13 @@ public final class SelectSongViewController: BaseViewController {
             self.searchTextField.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor),
             self.collectionView.bottomAnchor.constraint(equalTo: self.searchTextField.topAnchor,
                                                         constant: -Metric.searchTextFieldBottomSpacing)
+        ])
+        
+        self.view.addSubview(self.loadingIndicator)
+        self.loadingIndicator.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            self.loadingIndicator.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+            self.loadingIndicator.centerYAnchor.constraint(equalTo: self.collectionView.centerYAnchor)
         ])
     }
     
@@ -219,8 +238,8 @@ extension SelectSongViewController: UICollectionViewDelegate {
         #if DEBUG
         MSLogger.make(category: .selectSong).log("\(item.title) selected")
         #endif
-        self.navigationDelegate?.navigateToSaveJourney(recordingJourney: self.viewModel.state.recordingJourney,
-                                                       lastCoordinate: self.viewModel.state.lastCoordinate,
+        self.navigationDelegate?.navigateToSaveJourney(recordingJourney: self.viewModel.recordingJourney,
+                                                       lastCoordinate: self.viewModel.lastCoordinate,
                                                        selectedSong: item,
                                                        selectedIndex: indexPath)
     }

--- a/iOS/Features/SelectSong/Sources/SelectSong/Presentation/SelectSongViewModel.swift
+++ b/iOS/Features/SelectSong/Sources/SelectSong/Presentation/SelectSongViewModel.swift
@@ -33,7 +33,6 @@ public final class SelectSongViewModel {
     
     public var state: State
     
-    private var musicAuthorizationState: MusicAuthorization.Status?
     let recordingJourney: RecordingJourney
     let lastCoordinate: Coordinate
     
@@ -54,12 +53,6 @@ public final class SelectSongViewModel {
         switch action {
         case .viewNeedsLoaded:
             Task {
-                let status = await MusicAuthorization.request()
-                #if DEBUG
-                MSLogger.make(category: .selectSong).debug("음악 권한 상태: \(status)")
-                #endif
-                self.musicAuthorizationState = status
-                
                 if #available(iOS 16.0, *) {
                     Task {
                         let songs = await self.fetchSongByRank()
@@ -68,8 +61,6 @@ public final class SelectSongViewModel {
                 }
             }
         case .searchTextFieldDidUpdate(let text):
-            guard case .authorized = self.musicAuthorizationState else { return }
-            
             if #available(iOS 16.0, *), text.isEmpty {
                 Task {
                     let songs = await self.fetchSongByRank()

--- a/iOS/Features/SelectSong/Sources/SelectSong/Presentation/SelectSongViewModel.swift
+++ b/iOS/Features/SelectSong/Sources/SelectSong/Presentation/SelectSongViewModel.swift
@@ -11,6 +11,7 @@ import Foundation
 import MediaPlayer
 import MSData
 import MSDomain
+import MSLogger
 import MusicKit
 
 public final class SelectSongViewModel {
@@ -22,9 +23,8 @@ public final class SelectSongViewModel {
     
     public struct State {
         var songs = CurrentValueSubject<[Song], Never>([])
+        var isLoading = CurrentValueSubject<Bool, Never>(false)
         
-        let recordingJourney: RecordingJourney
-        let lastCoordinate: Coordinate
     }
     
     // MARK: - Properties
@@ -34,15 +34,18 @@ public final class SelectSongViewModel {
     public var state: State
     
     private var musicAuthorizationState: MusicAuthorization.Status?
+    let recordingJourney: RecordingJourney
+    let lastCoordinate: Coordinate
     
     // MARK: - Initializer
     
     public init(recordingJourney: RecordingJourney,
                 lastCoordinate: Coordinate,
                 repository: SongRepository) {
-        self.state = State(recordingJourney: recordingJourney,
-                           lastCoordinate: lastCoordinate)
         self.repository = repository
+        self.state = State()
+        self.recordingJourney = recordingJourney
+        self.lastCoordinate = lastCoordinate
     }
     
     // MARK: - Functions
@@ -52,23 +55,65 @@ public final class SelectSongViewModel {
         case .viewNeedsLoaded:
             Task {
                 let status = await MusicAuthorization.request()
+                #if DEBUG
+                MSLogger.make(category: .selectSong).debug("음악 권한 상태: \(status)")
+                #endif
                 self.musicAuthorizationState = status
-            }
-        case .searchTextFieldDidUpdate(let text):
-            switch self.musicAuthorizationState {
-            case .authorized:
-                Task {
-                    let result = await self.repository.fetchSongList(with: text)
-                    switch result {
-                    case .success(let songCollection):
-                        self.state.songs.send(songCollection.map { $0 })
-                    case .failure(let error):
-                        dump(error)
+                
+                if #available(iOS 16.0, *) {
+                    Task {
+                        let songs = await self.fetchSongByRank()
+                        self.state.songs.send(songs)
                     }
                 }
-            default:
+            }
+        case .searchTextFieldDidUpdate(let text):
+            guard case .authorized = self.musicAuthorizationState else { return }
+            
+            if #available(iOS 16.0, *), text.isEmpty {
+                Task {
+                    let songs = await self.fetchSongByRank()
+                    self.state.songs.send(songs)
+                }
                 return
             }
+            
+            Task {
+                let songs = await self.fetchSong(byTitle: text)
+                self.state.songs.send(songs)
+            }
+        }
+    }
+    
+}
+
+// MARK: - Private Functions
+
+private extension SelectSongViewModel {
+    
+    func fetchSong(byTitle title: String) async -> [Song] {
+        self.state.isLoading.send(true)
+        defer { self.state.isLoading.send(false) }
+        
+        let result = await self.repository.fetchSongList(with: title)
+        switch result {
+        case .success(let songCollection):
+            return songCollection.map { $0 }
+        case .failure(let error):
+            MSLogger.make(category: .selectSong).error("\(error)")
+            return []
+        }
+    }
+    
+    @available(iOS 16.0, *)
+    func fetchSongByRank() async -> [Song] {
+        let result = await self.repository.fetchSongListByRank()
+        switch result {
+        case .success(let chart):
+            return chart.map { $0 }
+        case .failure(let error):
+            MSLogger.make(category: .selectSong).error("\(error)")
+            return []
         }
     }
     

--- a/iOS/MSCoreKit/Sources/MSNetworking/HTTPBody.swift
+++ b/iOS/MSCoreKit/Sources/MSNetworking/HTTPBody.swift
@@ -48,7 +48,6 @@ public struct HTTPBody {
                 MSLogger.make(category: .network).error("HTTP Body 데이터 인코딩에 실패했습니다.")
                 return nil
             }
-            MSLogger.make(category: .network).debug("변환된 데이터: \(data)")
             return data
             
         case .multipart:

--- a/iOS/MSUIKit/Sources/MSUIKit/Cells/EmptyCell.swift
+++ b/iOS/MSUIKit/Sources/MSUIKit/Cells/EmptyCell.swift
@@ -1,0 +1,29 @@
+//
+//  EmptyCell.swift
+//  MSUIKit
+//
+//  Created by 이창준 on 2023.12.09.
+//
+
+import UIKit
+
+public final class EmptyCell: UICollectionViewCell {
+    
+    // MARK: - Initializer
+    
+    public override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.configureStyles()
+    }
+    
+    public required init?(coder: NSCoder) {
+        fatalError("MusicSpot은 code-based로만 작업 중입니다.")
+    }
+    
+    // MARK: - UI Configuration
+    
+    private func configureStyles() {
+        self.backgroundColor = .clear
+    }
+    
+}

--- a/iOS/MSUIKit/Sources/MSUIKit/Cells/SongListCell/SongListCell.swift
+++ b/iOS/MSUIKit/Sources/MSUIKit/Cells/SongListCell/SongListCell.swift
@@ -80,6 +80,12 @@ public final class SongListCell: UICollectionViewCell {
         fatalError("MusicSpot은 code-based로만 작업 중입니다.")
     }
     
+    // MARK: - Life Cycle
+    
+    public override func prepareForReuse() {
+        self.albumArtImageView.image = nil
+    }
+    
     // MARK: - Functions
     
     public func update(with cellModel: SongListCellModel) {

--- a/iOS/MSUIKit/Sources/MSUIKit/Cells/SongListCell/SongListCellModel.swift
+++ b/iOS/MSUIKit/Sources/MSUIKit/Cells/SongListCell/SongListCellModel.swift
@@ -7,15 +7,18 @@
 
 import Foundation
 
-public struct SongListCellModel {
+public struct SongListCellModel: Identifiable {
     
+    public let id: String
     let title: String
     let artist: String
     let albumArtURL: URL?
     
-    public init(title: String,
+    public init(id: String,
+                title: String,
                 artist: String,
                 albumArtURL: URL?) {
+        self.id = id
         self.title = title
         self.artist = artist
         self.albumArtURL = albumArtURL

--- a/iOS/MusicSpot/MusicSpot.xcodeproj/project.pbxproj
+++ b/iOS/MusicSpot/MusicSpot.xcodeproj/project.pbxproj
@@ -382,7 +382,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.1;
+				MARKETING_VERSION = 0.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = kr.codesquad.boostcamp8.MusicSpot;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -420,7 +420,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.1;
+				MARKETING_VERSION = 0.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = kr.codesquad.boostcamp8.MusicSpot;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -522,7 +522,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.1;
+				MARKETING_VERSION = 0.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = kr.codesquad.boostcamp8.MusicSpot;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/iOS/MusicSpot/MusicSpot.xcodeproj/project.pbxproj
+++ b/iOS/MusicSpot/MusicSpot.xcodeproj/project.pbxproj
@@ -368,7 +368,7 @@
 				INFOPLIST_FILE = MusicSpot/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = MusicSpot;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.travel";
-				INFOPLIST_KEY_NSAppleMusicUsageDescription = "음악을 재생하기 위해 미디어 라이브러리 접근 권한이 필요합니다.";
+				INFOPLIST_KEY_NSAppleMusicUsageDescription = "음악 기능을 사용하기 위해서는 미디어 라이브러리 사용 권한이 필요합니다.";
 				INFOPLIST_KEY_NSCameraUsageDescription = "스팟을 남기기 위한 카메라 접근 권한이 필요합니다.";
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "사용자의 위치 정보에 대한 엑세스가 필요합니다.";
 				INFOPLIST_KEY_NSLocationUsageDescription = "사용자의 위치 정보를 통해 실시간 위치 표시 및 데이터를 제공해드립니다.";
@@ -406,7 +406,7 @@
 				INFOPLIST_FILE = MusicSpot/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = MusicSpot;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.travel";
-				INFOPLIST_KEY_NSAppleMusicUsageDescription = "음악을 재생하기 위해 미디어 라이브러리 접근 권한이 필요합니다.";
+				INFOPLIST_KEY_NSAppleMusicUsageDescription = "음악 기능을 사용하기 위해서는 미디어 라이브러리 사용 권한이 필요합니다.";
 				INFOPLIST_KEY_NSCameraUsageDescription = "스팟을 남기기 위한 카메라 접근 권한이 필요합니다.";
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "사용자의 위치 정보에 대한 엑세스가 필요합니다.";
 				INFOPLIST_KEY_NSLocationUsageDescription = "사용자의 위치 정보를 통해 실시간 위치 표시 및 데이터를 제공해드립니다.";
@@ -508,7 +508,7 @@
 				INFOPLIST_FILE = MusicSpot/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = MusicSpot;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.travel";
-				INFOPLIST_KEY_NSAppleMusicUsageDescription = "음악을 재생하기 위해 미디어 라이브러리 접근 권한이 필요합니다.";
+				INFOPLIST_KEY_NSAppleMusicUsageDescription = "음악 기능을 사용하기 위해서는 미디어 라이브러리 사용 권한이 필요합니다.";
 				INFOPLIST_KEY_NSCameraUsageDescription = "스팟을 남기기 위한 카메라 접근 권한이 필요합니다.";
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "사용자의 위치 정보에 대한 엑세스가 필요합니다.";
 				INFOPLIST_KEY_NSLocationUsageDescription = "사용자의 위치 정보를 통해 실시간 위치 표시 및 데이터를 제공해드립니다.";

--- a/iOS/MusicSpot/MusicSpot/MSCoordinator/SaveJourneyCoordinator.swift
+++ b/iOS/MusicSpot/MusicSpot/MSCoordinator/SaveJourneyCoordinator.swift
@@ -38,13 +38,11 @@ final class SaveJourneyCoordinator: Coordinator {
     
     func start(recordingJourney: RecordingJourney,
                lastCoordinate: Coordinate,
-               selectedSong: Song,
-               selectedIndex: IndexPath) {
+               selectedSong: Song) {
         let journeyRepository = JourneyRepositoryImplementation()
         let saveJourneyViewModel = SaveJourneyViewModel(recordingJourney: recordingJourney,
                                                         lastCoordinate: lastCoordinate,
                                                         selectedSong: selectedSong,
-                                                        selectedIndex: selectedIndex,
                                                         journeyRepository: journeyRepository)
         let saveJourneyViewController = SaveJourneyViewController(viewModel: saveJourneyViewModel)
         saveJourneyViewController.navigationDelegate = self

--- a/iOS/MusicSpot/MusicSpot/MSCoordinator/SelectSongCoordinator.swift
+++ b/iOS/MusicSpot/MusicSpot/MSCoordinator/SelectSongCoordinator.swift
@@ -67,8 +67,7 @@ extension SelectSongCoordinator: SelectSongNavigationDelegate {
         self.childCoordinators.append(saveJourneyCoordinator)
         saveJourneyCoordinator.start(recordingJourney: recordingJourney,
                                      lastCoordinate: lastCoordinate,
-                                     selectedSong: selectedSong,
-                                     selectedIndex: selectedIndex)
+                                     selectedSong: selectedSong)
     }
     
 }

--- a/iOS/MusicSpot/MusicSpot/MSCoordinator/SelectSongCoordinator.swift
+++ b/iOS/MusicSpot/MusicSpot/MSCoordinator/SelectSongCoordinator.swift
@@ -60,8 +60,7 @@ extension SelectSongCoordinator: SelectSongNavigationDelegate {
     
     func navigateToSaveJourney(recordingJourney: RecordingJourney,
                                lastCoordinate: Coordinate,
-                               selectedSong: Song,
-                               selectedIndex: IndexPath) {
+                               selectedSong: Song) {
         let saveJourneyCoordinator = SaveJourneyCoordinator(navigationController: self.navigationController)
         saveJourneyCoordinator.delegate = self
         self.childCoordinators.append(saveJourneyCoordinator)


### PR DESCRIPTION
## ❗ 배경
> 작업 배경에 대한 설명을 작성합니다.
> Issue에 대한 링크를 첨부합니다.

- close #254 

## 🔧 작업 내역
> 작업한 내용들을 나열합니다.
> 간결하게 리스트 업하고, 자세한 설명은 아래 리뷰 노트에서 합니다.

- 음악 검색 기능 개선
- 음악 재생 기능 추가

## 🧪 테스트 방법
> 동작을 테스트할 수 있는 방법을 설명합니다.
> 앱 실행 방법일 수 있고, 유닛 테스트 실행 방법일 수 있습니다.

## 📝 리뷰 노트
> 작업 내역에 대한 자세한 설명을 작성합니다.

### 음악 검색 기능 개선

애플 Music쪽이 그래도 딜레이가 조금 있더라구요.
그래서 네트워크 요청을 한 뒤 응답을 받을 때까지 로딩 인디케이터를 추가해주었습니다.

그리고 아무 입력이 없을 때 화면이 조금 비어있는게 아쉽더군요.
이 때 한국 차트를 보여주면 어떨까 싶어서 추가해봤습니다.

다만 MusicKit에서 해당 기능이 iOS 16.0부터 지원되는 API라서 그 이상 버전에서만 화면에 표현됩니다..

### 애플 뮤직 구독자가 아닐 시 구독 화면

놀랍게도 MusicKit의 기능을 사용하려면 SwiftUI를 사용해야 했습니다.
그래서 버튼을 SwiftUI로 다시 만들었습니다...

`UIHostingController`와 `ObservableObject` 개념을 사용했습니다.

```swift
final class ButtonStateFactor: ObservableObject {
    
    @Published var canBecomeSubscriber: Bool = false
    @Published var isMusicPlaying: Bool = false
    
}
```

## 📸 스크린샷
> 작업한 내용에 대한 스크린샷, 영상 등을 첨부합니다.

| 데모 영상 |
| :-: |
| <img src="https://github.com/boostcampwm2023/iOS01-MusicSpot/assets/138548400/fa94140d-f982-4c04-b10a-5082d3c73716" width="300"> |
