### PR TITLE
[iOS] 송신 이미지 확장자 변경 및 다운샘플링

### DIFF
--- a/iOS/Features/Spot/Sources/Spot/Presentation/SpotSaveViewController.swift
+++ b/iOS/Features/Spot/Sources/Spot/Presentation/SpotSaveViewController.swift
@@ -245,11 +245,11 @@ public final class SpotSaveViewController: UIViewController {
     }
     
     private func completeButtonDidTap() {
-        guard let pngData = self.image.pngData() else {
+        guard let jpegData = self.image.jpegData(compressionQuality: 0.1) else {
             MSLogger.make(category: .spot).debug("현재 이미지를 Data로 변환할 수 없습니다.")
             return
         }
-        self.viewModel.trigger(.startUploadSpot, using: UIImage(systemName: "pencil")!.pngData()!)
+        self.viewModel.trigger(.startUploadSpot, using: jpegData)
         self.navigationDelegate?.popToHome()
     }
     

--- a/iOS/MSCoreKit/Sources/MSNetworking/MultipartData.swift
+++ b/iOS/MSCoreKit/Sources/MSNetworking/MultipartData.swift
@@ -21,6 +21,7 @@ public struct MultipartData {
     private let type: ContentType
     public let name: String
     public let content: Encodable
+    private let imageType: String = "jpeg"
     
     // MARK: - Initializer
     
@@ -49,7 +50,7 @@ public struct MultipartData {
             
         case .image:
             let dispositionDescript = "Content-Disposition: form-data; name=\"image\"; filename=\"test.png\"\r\n"
-            let typeDescript = "Content-Type: image/png\r\n\r\n"
+            let typeDescript = "Content-Type: image/\(self.imageType)\r\n\r\n"
             if let disposition = dispositionDescript.data(using: .utf8),
                let type = typeDescript.data(using: .utf8),
                let contentData = self.content as? Data {


### PR DESCRIPTION
## 🔧 작업 내역
> 작업한 내용들을 나열합니다.
> 간결하게 리스트 업하고, 자세한 설명은 아래 리뷰 노트에서 합니다.

multipart로 이미지를 서버에 보낼 경우, 다운 샘플링을 하여 보내도록 수정하였습니다.

## 🧪 테스트 방법
> 동작을 테스트할 수 있는 방법을 설명합니다.
> 앱 실행 방법일 수 있고, 유닛 테스트 실행 방법일 수 있습니다.

## 📝 리뷰 노트
> 작업 내역에 대한 자세한 설명을 작성합니다.

## 📸 스크린샷
> 작업한 내용에 대한 스크린샷, 영상 등을 첨부합니다.
