### PR TITLE
[iOS] 여정 삭제 API 추가

### DIFF
--- a/iOS/Features/Home/Sources/Home/Presentation/HomeViewController.swift
+++ b/iOS/Features/Home/Sources/Home/Presentation/HomeViewController.swift
@@ -147,8 +147,15 @@ public final class HomeViewController: HomeBottomSheetViewController {
         
         self.viewModel.state.isStartButtonLoading
             .receive(on: DispatchQueue.main)
-            .sink { isStartButtonLoading in
-                self.startButton.configuration?.showsActivityIndicator = isStartButtonLoading
+            .sink { [weak self] isStartButtonLoading in
+                self?.startButton.configuration?.showsActivityIndicator = isStartButtonLoading
+            }
+            .store(in: &self.cancellables)
+        
+        self.viewModel.state.overlaysShouldBeCleared
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.contentViewController.clearOverlays()
             }
             .store(in: &self.cancellables)
     }
@@ -205,10 +212,8 @@ extension HomeViewController: RecordJourneyButtonViewDelegate {
     public func backButtonDidTap(_ button: MSRectButton) {
         guard self.viewModel.state.isRecording.value == true else { return }
         
-        self.contentViewController.clearOverlays()
         self.viewModel.trigger(.backButtonDidTap)
         self.contentViewController.journeyDidCancelled()
-        // TODO: 여정 취소
     }
     
     public func spotButtonDidTap(_ button: MSRectButton) {

--- a/iOS/Features/Home/Sources/Home/Presentation/HomeViewModel.swift
+++ b/iOS/Features/Home/Sources/Home/Presentation/HomeViewModel.swift
@@ -31,6 +31,7 @@ public final class HomeViewModel {
         // Passthrough
         public var startedJourney = PassthroughSubject<RecordingJourney, Never>()
         public var visibleJourneys = PassthroughSubject<[Journey], Never>()
+        public var overlaysShouldBeCleared = PassthroughSubject<Bool, Never>()
         
         // CurrentValue
         public var isRecording = CurrentValueSubject<Bool, Never>(false)
@@ -83,6 +84,7 @@ public final class HomeViewModel {
             self.fetchJourneys(minCoordinate: minCoordinate, maxCoordinate: maxCoordinate)
         case .backButtonDidTap:
             self.state.isRecording.send(false)
+            self.state.overlaysShouldBeCleared.send(true)
         }
     }
     

--- a/iOS/Features/Home/Sources/NavigateMap/Presentation/Common/MapViewController+EventListener.swift
+++ b/iOS/Features/Home/Sources/NavigateMap/Presentation/Common/MapViewController+EventListener.swift
@@ -27,13 +27,21 @@ extension MapViewController {
 extension MapViewController {
     
     public func journeyDidStarted(_ startedJourney: RecordingJourney) {
+        let userRepository = UserRepositoryImplementation()
         let journeyRepository = JourneyRepositoryImplementation()
-        let viewModel = RecordJourneyViewModel(startedJourney: startedJourney, journeyRepository: journeyRepository)
+        let viewModel = RecordJourneyViewModel(startedJourney: startedJourney,
+                                               userRepository: userRepository,
+                                               journeyRepository: journeyRepository)
         self.swapViewModel(to: viewModel)
     }
     
     public func journeyDidCancelled() {
+        guard let viewModel = self.viewModel as? RecordJourneyViewModel else { return }
+        viewModel.trigger(.recordingDidCancelled)
         
+        let journeyRepository = JourneyRepositoryImplementation()
+        let navigateMapViewModel = NavigateMapViewModel(repository: journeyRepository)
+        self.swapViewModel(to: navigateMapViewModel)
     }
     
 }

--- a/iOS/MSData/Package.swift
+++ b/iOS/MSData/Package.swift
@@ -69,8 +69,6 @@ let package = Package(
                              package: Dependency.msCoreKit),
                     .product(name: Dependency.msPersistentStorage,
                              package: Dependency.msCoreKit),
-                    .product(name: Dependency.msPersistentStorage,
-                             package: Dependency.msCoreKit),
                     .product(name: Dependency.msLogger,
                              package: Dependency.msFoundation),
                     .product(name: Dependency.msUserDefaults,

--- a/iOS/MSData/Sources/MSData/DTO/Fragment/JourneyMetadataDTO.swift
+++ b/iOS/MSData/Sources/MSData/DTO/Fragment/JourneyMetadataDTO.swift
@@ -7,9 +7,31 @@
 
 import Foundation
 
-public struct JourneyMetadataDTO: Codable {
+public struct JourneyMetadataDTO {
     
     public let startTimestamp: Date
     public let endTimestamp: Date
+    
+}
+
+// MARK: - Codable
+
+extension JourneyMetadataDTO: Codable {
+    
+    enum CodingKeys: String, CodingKey {
+        case startTimestamp
+        case endTimestamp
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.startTimestamp = try container.decode(Date.self, forKey: .startTimestamp)
+        if let endTimestamp = try? container.decode(String.self, forKey: .endTimestamp),
+           endTimestamp.isEmpty {
+            self.endTimestamp = .now
+            return
+        }
+        self.endTimestamp = try container.decode(Date.self, forKey: .endTimestamp)
+    }
     
 }

--- a/iOS/MSData/Sources/MSData/DTO/Request/Journey/DeleteJourneyRequestDTO.swift
+++ b/iOS/MSData/Sources/MSData/DTO/Request/Journey/DeleteJourneyRequestDTO.swift
@@ -1,0 +1,15 @@
+//
+//  DeleteJourneyRequestDTO.swift
+//  MSData
+//
+//  Created by 이창준 on 2023.12.10.
+//
+
+import Foundation
+
+public struct DeleteJourneyRequestDTO: Encodable {
+    
+    public let userID: UUID
+    public let journeyID: String
+    
+}

--- a/iOS/MSData/Sources/MSData/DTO/Request/Journey/DeleteJourneyRequestDTO.swift
+++ b/iOS/MSData/Sources/MSData/DTO/Request/Journey/DeleteJourneyRequestDTO.swift
@@ -9,7 +9,16 @@ import Foundation
 
 public struct DeleteJourneyRequestDTO: Encodable {
     
+    // MARK: - Properties
+    
     public let userID: UUID
     public let journeyID: String
+    
+    // MARK: - Encodable
+    
+    enum CodingKeys: String, CodingKey {
+        case userID = "userId"
+        case journeyID = "journeyId"
+    }
     
 }

--- a/iOS/MSData/Sources/MSData/DTO/Request/Journey/EndJourneyRequestDTO.swift
+++ b/iOS/MSData/Sources/MSData/DTO/Request/Journey/EndJourneyRequestDTO.swift
@@ -47,14 +47,4 @@ extension EndJourneyRequestDTO: Encodable {
         case song
     }
     
-//    public func encode(to encoder: Encoder) throws {
-//        var container = encoder.container(keyedBy: CodingKeys.self)
-//        try container.encode(self.journeyID, forKey: .journeyID)
-//        try container.encode(self.coordinates, forKey: .coordinates)
-//        try container.encode(self.endTimestamp., forKey: .title)
-//        try container.encode(self.spots, forKey: .spots)
-//        try container.encode(self.coordinates, forKey: .coordinates)
-//        try container.encode(self.coordinates, forKey: .coordinates)
-//    }
-    
 }

--- a/iOS/MSData/Sources/MSData/DTO/Response/Journey/DeleteJourneyResponseDTO.swift
+++ b/iOS/MSData/Sources/MSData/DTO/Response/Journey/DeleteJourneyResponseDTO.swift
@@ -1,0 +1,44 @@
+//
+//  DeleteJourneyResponseDTO.swift
+//  MSData
+//
+//  Created by 이창준 on 2023.12.10.
+//
+
+import Foundation
+
+public struct DeleteJourneyResponseDTO: Identifiable {
+    
+    // MARK: - Properties
+    
+    public let id: String
+    public let metadata: JourneyMetadataDTO
+    public let spots: [SpotDTO]
+    public let coordinates: [CoordinateDTO]
+    
+    // MARK: - Initializer
+    
+    public init(id: String,
+                metadata: JourneyMetadataDTO,
+                spots: [SpotDTO],
+                coordinates: [CoordinateDTO]) {
+        self.id = id
+        self.metadata = metadata
+        self.spots = spots
+        self.coordinates = coordinates
+    }
+    
+}
+
+// MARK: - Decodable
+
+extension DeleteJourneyResponseDTO: Decodable {
+    
+    enum CodingKeys: String, CodingKey {
+        case id = "_id"
+        case metadata = "journeyMetadata"
+        case spots
+        case coordinates
+    }
+    
+}

--- a/iOS/MSData/Sources/MSData/Repository/JourneyRepository.swift
+++ b/iOS/MSData/Sources/MSData/Repository/JourneyRepository.swift
@@ -24,6 +24,7 @@ public protocol JourneyRepository {
     mutating func startJourney(at coordinate: Coordinate, userID: UUID) async -> Result<RecordingJourney, Error>
     mutating func endJourney(_ journey: Journey) async -> Result<String, Error>
     func recordJourney(journeyID: String, at coordinates: [Coordinate]) async -> Result<RecordingJourney, Error>
+    mutating func deleteJourney(_ journey: RecordingJourney, userID: UUID) async -> Result<Journey, Error>
     
 }
 
@@ -148,6 +149,20 @@ public struct JourneyRepositoryImplementation: JourneyRepository {
         case .success(let responseDTO):
             self.recordingJourneyID = nil
             return .success(responseDTO.id)
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
+    
+    public mutating func deleteJourney(_ recordingJourney: RecordingJourney,
+                                       userID: UUID) async -> Result<Journey, Error> {
+        let requestDTO = DeleteJourneyRequestDTO(userID: userID, journeyID: recordingJourney.id)
+        let router = JourneyRouter.deleteJourney(dto: requestDTO)
+        let result = await self.networking.request(JourneyDTO.self, router: router)
+        switch result {
+        case .success(let responseDTO):
+            self.recordingJourneyID = nil
+            return .success(responseDTO.toDomain())
         case .failure(let error):
             return .failure(error)
         }

--- a/iOS/MSData/Sources/MSData/Repository/JourneyRepository.swift
+++ b/iOS/MSData/Sources/MSData/Repository/JourneyRepository.swift
@@ -24,7 +24,7 @@ public protocol JourneyRepository {
     mutating func startJourney(at coordinate: Coordinate, userID: UUID) async -> Result<RecordingJourney, Error>
     mutating func endJourney(_ journey: Journey) async -> Result<String, Error>
     func recordJourney(journeyID: String, at coordinates: [Coordinate]) async -> Result<RecordingJourney, Error>
-    mutating func deleteJourney(_ journey: RecordingJourney, userID: UUID) async -> Result<Journey, Error>
+    mutating func deleteJourney(_ journey: RecordingJourney, userID: UUID) async -> Result<String, Error>
     
 }
 
@@ -155,14 +155,14 @@ public struct JourneyRepositoryImplementation: JourneyRepository {
     }
     
     public mutating func deleteJourney(_ recordingJourney: RecordingJourney,
-                                       userID: UUID) async -> Result<Journey, Error> {
+                                       userID: UUID) async -> Result<String, Error> {
         let requestDTO = DeleteJourneyRequestDTO(userID: userID, journeyID: recordingJourney.id)
         let router = JourneyRouter.deleteJourney(dto: requestDTO)
-        let result = await self.networking.request(JourneyDTO.self, router: router)
+        let result = await self.networking.request(DeleteJourneyResponseDTO.self, router: router)
         switch result {
         case .success(let responseDTO):
             self.recordingJourneyID = nil
-            return .success(responseDTO.toDomain())
+            return .success(responseDTO.id)
         case .failure(let error):
             return .failure(error)
         }

--- a/iOS/MSData/Sources/MSData/Router/Journey/JourneyRouter+Body.swift
+++ b/iOS/MSData/Sources/MSData/Router/Journey/JourneyRouter+Body.swift
@@ -17,6 +17,8 @@ extension JourneyRouter {
             return HTTPBody(content: dto)
         case let .recordCoordinate(dto):
             return HTTPBody(content: dto)
+        case let .deleteJourney(dto):
+            return HTTPBody(content: dto)
         default: return nil
         }
     }

--- a/iOS/MSData/Sources/MSData/Router/Journey/JourneyRouter+Method.swift
+++ b/iOS/MSData/Sources/MSData/Router/Journey/JourneyRouter+Method.swift
@@ -16,6 +16,7 @@ extension JourneyRouter {
         case .recordCoordinate: return .post
         case .checkJourney: return .get
         case .loadLastJourney: return .get
+        case .deleteJourney: return .delete
         }
     }
     

--- a/iOS/MSData/Sources/MSData/Router/Journey/JourneyRouter+URL.swift
+++ b/iOS/MSData/Sources/MSData/Router/Journey/JourneyRouter+URL.swift
@@ -26,6 +26,7 @@ extension JourneyRouter {
         case .recordCoordinate: return "record"
         case .checkJourney: return "check"
         case .loadLastJourney: return "loadLastData"
+        case .deleteJourney: return nil
         }
     }
     

--- a/iOS/MSData/Sources/MSData/Router/Journey/JourneyRouter.swift
+++ b/iOS/MSData/Sources/MSData/Router/Journey/JourneyRouter.swift
@@ -21,5 +21,7 @@ public enum JourneyRouter: Router {
     case checkJourney(userID: UUID, minCoordinate: CoordinateDTO, maxCoordinate: CoordinateDTO)
     /// 진행 중인 여정이 있는 지 확인하고, 있다면 여정 정보를 반환합니다.
     case loadLastJourney(userID: UUID)
+    /// 여정 ID에 따른 여정 삭제
+    case deleteJourney(dto: DeleteJourneyRequestDTO)
     
 }

--- a/iOS/MSDomain/Sources/MSDomain/Model/Journey.swift
+++ b/iOS/MSDomain/Sources/MSDomain/Model/Journey.swift
@@ -49,3 +49,19 @@ extension Journey: Hashable {
     }
     
 }
+
+// MARK: - String Convertible
+
+extension Journey: CustomStringConvertible {
+    
+    public var description: String {
+        return """
+        Journey
+        - title: \(self.title)
+        - date:
+          - start: \(self.date.start)
+          - end: \(self.date.end)
+        """
+    }
+    
+}


### PR DESCRIPTION
## 🔧 작업 내역
> 작업한 내용들을 나열합니다.
> 간결하게 리스트 업하고, 자세한 설명은 아래 리뷰 노트에서 합니다.

- 여정 삭제 API 추가
- 여정 삭제 기능 추가

## 📝 리뷰 노트
> 작업 내역에 대한 자세한 설명을 작성합니다.

### DeleteJourneyResponseDTO

기존 `JourneyDTO`를 그대로 응답 디코딩에 사용하려고 했지만..
`metaData.endTimestamp`, `song`, `title`이 응답에서 제외된 것을 확인했습니다.

다른 값들은 대응이 어느정도 수월하지만 `song`의 경우 그렇지 못해서 별도의 `ResponseDTO`를 만들어줬습니다.

```Swift
import Foundation

public struct DeleteJourneyResponseDTO: Identifiable {
    
    // MARK: - Properties
    
    public let id: String
    public let metadata: JourneyMetadataDTO
    public let spots: [SpotDTO]
    public let coordinates: [CoordinateDTO]
    
    // MARK: - Initializer
    
    public init(id: String,
                metadata: JourneyMetadataDTO,
                spots: [SpotDTO],
                coordinates: [CoordinateDTO]) {
        self.id = id
        self.metadata = metadata
        self.spots = spots
        self.coordinates = coordinates
    }
    
}

// MARK: - Decodable

extension DeleteJourneyResponseDTO: Decodable {
    
    enum CodingKeys: String, CodingKey {
        case id = "_id"
        case metadata = "journeyMetadata"
        case spots
        case coordinates
    }
    
}
```