### PR TITLE
[iOS] 여정 목록 헤더 & UserID 관련 로직 수정

### DIFF
--- a/iOS/Features/Home/Sources/Home/Presentation/HomeViewModel.swift
+++ b/iOS/Features/Home/Sources/Home/Presentation/HomeViewModel.swift
@@ -68,12 +68,12 @@ public final class HomeViewModel {
     func trigger(_ action: Action) {
         switch action {
         case .viewNeedsLoaded:
+            #if DEBUG
             let firstLaunchMessage = self.isFirstLaunch ? "앱이 처음 실행되었습니다." : "앱 첫 실행이 아닙니다."
-            MSLogger.make(category: .userDefaults).log("\(firstLaunchMessage)")
+            MSLogger.make(category: .userDefaults).debug("\(firstLaunchMessage)")
+            #endif
             
-            if self.isFirstLaunch {
-                self.createNewUser()
-            }
+            self.createNewUserWhenFirstLaunch()
         case .viewNeedsReloaded:
             let isRecording = self.journeyRepository.fetchIsRecording()
             self.state.isRecording.send(isRecording)
@@ -99,7 +99,7 @@ public final class HomeViewModel {
 
 private extension HomeViewModel {
     
-    func createNewUser() {
+    func createNewUserWhenFirstLaunch() {
         guard self.isFirstLaunch else { return }
         
         Task {
@@ -121,10 +121,8 @@ private extension HomeViewModel {
             self.state.isStartButtonLoading.send(true)
             defer { self.state.isStartButtonLoading.send(false) }
             
-            let userID = try self.userRepository.fetchUUID()
-            #if DEBUG
-            MSLogger.make(category: .home).debug("유저 ID 조회 성공: \(userID)")
-            #endif
+            guard let userID = self.userRepository.fetchUUID() else { return }
+            
             let result = await self.journeyRepository.startJourney(at: coordinate, userID: userID)
             switch result {
             case .success(let recordingJourney):
@@ -137,7 +135,7 @@ private extension HomeViewModel {
     }
     
     func fetchJourneys(minCoordinate: Coordinate, maxCoordinate: Coordinate) {
-        guard let userID = try? self.userRepository.fetchUUID() else { return }
+        guard let userID = self.userRepository.fetchUUID() else { return }
         
         Task {
             let result = await self.journeyRepository.fetchJourneyList(userID: userID,

--- a/iOS/Features/Home/Sources/Home/Presentation/HomeViewModel.swift
+++ b/iOS/Features/Home/Sources/Home/Presentation/HomeViewModel.swift
@@ -68,10 +68,6 @@ public final class HomeViewModel {
     func trigger(_ action: Action) {
         switch action {
         case .viewNeedsLoaded:
-//            #if DEBUG
-//            self.isFirstLaunch = true
-//            try? self.keychain.deleteAll()
-//            #endif
             let firstLaunchMessage = self.isFirstLaunch ? "앱이 처음 실행되었습니다." : "앱 첫 실행이 아닙니다."
             MSLogger.make(category: .userDefaults).log("\(firstLaunchMessage)")
             

--- a/iOS/Features/Home/Sources/NavigateMap/Presentation/Common/MapViewController.swift
+++ b/iOS/Features/Home/Sources/NavigateMap/Presentation/Common/MapViewController.swift
@@ -313,7 +313,9 @@ extension MapViewController: CLLocationManagerDelegate {
         
         let coordinate2D = CLLocationCoordinate2D(latitude: newCurrentLocation.coordinate.latitude,
                                                   longitude: newCurrentLocation.coordinate.longitude)
+        
         recordJourneyViewModel.trigger(.locationDidUpdated(coordinate2D))
+        recordJourneyViewModel.trigger(.locationsShouldRecorded([coordinate2D]))
     }
     
     private func handleAuthorizationChange(_ manager: CLLocationManager) {

--- a/iOS/Features/Home/Sources/NavigateMap/Presentation/RecordJourney/RecordJourneyViewModel.swift
+++ b/iOS/Features/Home/Sources/NavigateMap/Presentation/RecordJourney/RecordJourneyViewModel.swift
@@ -73,7 +73,8 @@ public final class RecordJourneyViewModel: MapViewModel {
             }
         case .recordingDidCancelled:
             Task {
-                let userID = try self.userRepository.fetchUUID()
+                guard let userID = self.userRepository.fetchUUID() else { return }
+                
                 let recordingJourney = self.state.recordingJourney.value
                 let result = await self.journeyRepository.deleteJourney(recordingJourney, userID: userID)
                 switch result {

--- a/iOS/Features/JourneyList/Sources/JourneyList/Presentation/VIew/MSCollectionView.swift
+++ b/iOS/Features/JourneyList/Sources/JourneyList/Presentation/VIew/MSCollectionView.swift
@@ -11,9 +11,12 @@ final class MSCollectionView: UICollectionView {
     
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
         // Cell
+        let headers = self.visibleSupplementaryViews(ofKind: UICollectionView.elementKindSectionHeader)
         let cells = self.visibleCells
         for cell in cells where cell.frame.contains(point) {
-            return super.hitTest(point, with: event)
+            for header in headers where !header.frame.contains(point) {
+                return super.hitTest(point, with: event)
+            }
         }
         
         return nil

--- a/iOS/MSCoreKit/Sources/MSKeychainStorage/MSKeychainStorage.swift
+++ b/iOS/MSCoreKit/Sources/MSKeychainStorage/MSKeychainStorage.swift
@@ -68,7 +68,7 @@ public struct MSKeychainStorage {
     
     /// Keychain에 저장된 모든 데이터를 삭제합니다.
     public func deleteAll() throws {
-        for account in Accounts.allCases {
+        for account in Accounts.allCases where try self.exists(account: account.rawValue) {
             try self.delete(account: account.rawValue)
         }
     }

--- a/iOS/MSData/Sources/MSData/DTO/Response/Journey/RecordJourneyResponseDTO.swift
+++ b/iOS/MSData/Sources/MSData/DTO/Response/Journey/RecordJourneyResponseDTO.swift
@@ -1,5 +1,5 @@
 //
-//  RecordSpotResponseDTO.swift
+//  RecordJourneyResponseDTO.swift
 //  MSData
 //
 //  Created by 이창준 on 2023.12.06.
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct RecordSpotResponseDTO: Decodable {
+public struct RecordJourneyResponseDTO: Decodable {
     
     // MARK: - Properties
     

--- a/iOS/MSData/Sources/MSData/Repository/JourneyRepository.swift
+++ b/iOS/MSData/Sources/MSData/Repository/JourneyRepository.swift
@@ -156,11 +156,11 @@ public struct JourneyRepositoryImplementation: JourneyRepository {
         let coordinatesDTO = coordinates.map { CoordinateDTO($0) }
         let requestDTO = RecordCoordinateRequestDTO(journeyID: journeyID, coordinates: coordinatesDTO)
         let router = JourneyRouter.recordCoordinate(dto: requestDTO)
-        let result = await self.networking.request(RecordCoordinateRequestDTO.self, router: router)
+        let result = await self.networking.request(RecordJourneyResponseDTO.self, router: router)
         switch result {
         case .success(let responseDTO):
             let coordinates = responseDTO.coordinates.map { $0.toDomain() }
-            let recordingJourney = RecordingJourney(id: responseDTO.journeyID,
+            let recordingJourney = RecordingJourney(id: journeyID,
                                                     startTimestamp: Date(),
                                                     spots: [],
                                                     coordinates: coordinates)

--- a/iOS/MusicSpot/MusicSpot/SceneDelegate.swift
+++ b/iOS/MusicSpot/MusicSpot/SceneDelegate.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 import JourneyList
+import MSConstants
 import MSData
 import MSDesignSystem
 
@@ -17,6 +18,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     var window: UIWindow?
     private var appCoordinator: Coordinator!
+    
+    #if DEBUG
+    @UserDefaultsWrapped(UserDefaultsKey.recordingJourneyID, defaultValue: nil)
+    var recordingJourneyID: String?
+    @UserDefaultsWrapped(UserDefaultsKey.isFirstLaunch, defaultValue: false)
+    var isFirstLaunch: Bool
+    var keychain = MSKeychainStorage()
+    #endif
     
     // MARK: - Functions
     
@@ -51,3 +60,28 @@ private extension SceneDelegate {
     }
     
 }
+
+
+// MARK: - Debug
+
+#if DEBUG
+
+import MSKeychainStorage
+import MSLogger
+import MSUserDefaults
+
+private extension SceneDelegate {
+    
+    func prepareToDebug() {
+        self.isFirstLaunch = true
+        self.recordingJourneyID = nil
+        do {
+            try self.keychain.deleteAll()
+        } catch {
+            MSLogger.make(category: .keychain).error("키체인 초기화 실패")
+        }
+    }
+    
+}
+
+#endif


### PR DESCRIPTION

## 🔧 작업 내역
> 작업한 내용들을 나열합니다.
> 간결하게 리스트 업하고, 자세한 설명은 아래 리뷰 노트에서 합니다.

- 여정 리스트를 밑으로 내리면 상단 Pan Gesture로 크기 조정이 되지 않는 현상 (헤더를 Cell이 덮기 시작한 시점)
- UserID 관련 수정

## 📝 리뷰 노트
> 작업 내역에 대한 자세한 설명을 작성합니다.

### hitTest

`hitTest`를 사용해 터치 여부를 결정하고 있는데, cell이 헤더보다 밑에 위치해 겹치는 경우 cell이 터치되게 됩니다.
때문에 cell이 터치된 경우에도 header가 영역에 존재하는지를 확인하는 로직을 추가했습니다.

### UserID

기존에 `fetchUUID` 메서드에 `fetch` 로직 뿐만 아니라 없을 경우 새로 생성하는 로직이 포함되어 있었는데,
이것 때문에 착오가 생기지 않았을까 싶습니다.
해당 문제 수정해두었습니다.

### DEBUG scheme

`HomeViewModel` 의 `viewNeedsLoaded`에서 수행하던 앱 정보 초기화 로직을
`SceneDelegate`로 옮겼습니다.
