### PR TITLE
[iOS] 실시간으로 Coordinate 기록 시 위치 필터링 구현

### DIFF
--- a/iOS/Features/Home/Sources/Home/Presentation/HomeViewModel.swift
+++ b/iOS/Features/Home/Sources/Home/Presentation/HomeViewModel.swift
@@ -88,12 +88,12 @@ public final class HomeViewModel {
             self.fetchJourneys(minCoordinate: minCoordinate, maxCoordinate: maxCoordinate)
         case .backButtonDidTap:
             self.state.isRecording.send(false)
+            self.state.isRefreshButtonHidden.send(false)
             self.state.overlaysShouldBeCleared.send(true)
         case .mapViewDidChange:
             if self.state.isRecording.value == false {
                 self.state.isRefreshButtonHidden.send(false)
             }
-            self.state.isRefreshButtonHidden.send(false)
         }
     }
     

--- a/iOS/Features/Home/Sources/NavigateMap/Presentation/Common/MapViewController.swift
+++ b/iOS/Features/Home/Sources/NavigateMap/Presentation/Common/MapViewController.swift
@@ -243,7 +243,11 @@ public final class MapViewController: UIViewController {
                             CLLocationCoordinate2D(latitude: $0.latitude,
                                                    longitude: $0.longitude)
                         }
-                        await self.drawPolylineToMap(using: coordinates)
+                        let spotCoordinates = journey.spots.map {
+                            CLLocationCoordinate2D(latitude: $0.coordinate.latitude,
+                                                   longitude: $0.coordinate.longitude)
+                        }
+                        await self.drawPolylineToMap(using: coordinates+spotCoordinates)
                     }
                 }
             }

--- a/iOS/Features/Home/Sources/NavigateMap/Presentation/Common/MapViewController.swift
+++ b/iOS/Features/Home/Sources/NavigateMap/Presentation/Common/MapViewController.swift
@@ -315,6 +315,12 @@ extension MapViewController: CLLocationManagerDelegate {
               let recordJourneyViewModel = self.viewModel as? RecordJourneyViewModel else {
             return
         }
+        let previousCoordinate = (self.viewModel as? RecordJourneyViewModel)?.state.previousCoordinate.value
+        if self.timeRemaining != 0 || viewModel is NavigateMapViewModel { return }
+        if let previousCoordinate {
+            if !self.isDistanceOver5AndUnder50(coordinate1: previousCoordinate,
+                                               coordinate2: newCurrentLocation.coordinate) { return }
+        }
         
         let coordinate2D = CLLocationCoordinate2D(latitude: newCurrentLocation.coordinate.latitude,
                                                   longitude: newCurrentLocation.coordinate.longitude)
@@ -365,6 +371,7 @@ extension MapViewController: CLLocationManagerDelegate {
                                            coordinate2: CLLocationCoordinate2D) -> Bool {
         let location1 = CLLocation(latitude: coordinate1.latitude, longitude: coordinate1.longitude)
         let location2 = CLLocation(latitude: coordinate2.latitude, longitude: coordinate2.longitude)
+        MSLogger.make(category: .navigateMap).log("이동한 거리: \(location1.distance(from: location2))")
         return 5 <= location1.distance(from: location2) && location1.distance(from: location2) <= 50
     }
     

--- a/iOS/MusicSpot/MusicSpot/SceneDelegate.swift
+++ b/iOS/MusicSpot/MusicSpot/SceneDelegate.swift
@@ -12,6 +12,7 @@ import MSConstants
 import MSData
 import MSDesignSystem
 import MSLogger
+import MSUserDefaults
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
@@ -20,7 +21,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
     private var appCoordinator: Coordinator!
     
-    #if DEBUG
     @UserDefaultsWrapped(UserDefaultsKey.recordingJourneyID, defaultValue: nil)
     var recordingJourneyID: String?
     @UserDefaultsWrapped(UserDefaultsKey.isFirstLaunch, defaultValue: false)
@@ -28,6 +28,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     @UserDefaultsWrapped(UserDefaultsKey.isRecording, defaultValue: false)
     var isRecording: Bool
     
+    #if DEBUG
     var keychain = MSKeychainStorage()
     #endif
     
@@ -76,7 +77,6 @@ private extension SceneDelegate {
 
 #if DEBUG
 import MSKeychainStorage
-import MSUserDefaults
 
 private extension SceneDelegate {
     

--- a/iOS/MusicSpot/MusicSpot/SceneDelegate.swift
+++ b/iOS/MusicSpot/MusicSpot/SceneDelegate.swift
@@ -71,7 +71,6 @@ private extension SceneDelegate {
     
 }
 
-
 // MARK: - Debug
 
 #if DEBUG


### PR DESCRIPTION
## ❗ 배경
> 작업 배경에 대한 설명을 작성합니다.
> Issue에 대한 링크를 첨부합니다.

여정을 기록 시 모든 위치 값을 기록하는 것을 방지하는 로직을 구현했습니다.

## 🔧 작업 내역
> 작업한 내용들을 나열합니다.
> 간결하게 리스트 업하고, 자세한 설명은 아래 리뷰 노트에서 합니다.

- 여정을 기록 시 5초마다 위치가 5m초과 50m미만의 거리를 이동하였을 경우에만 기록이 되도록 구현했습니다.
- 5초 내로 기록이 안되었다면 다음 5초 후를 기준으로 위치 비교를 하도록 구현했습니다.

## 🧪 테스트 방법
> 동작을 테스트할 수 있는 방법을 설명합니다.
> 앱 실행 방법일 수 있고, 유닛 테스트 실행 방법일 수 있습니다.

## 📝 리뷰 노트
> 작업 내역에 대한 자세한 설명을 작성합니다.

### 위치 보정에 대한 고민

#### 5초, 5m< distance <50m의 기준은 임의로 정한 것이기에 정확도가 높은, 모든 상황을 고려한 필터링은 아닙니다.
- 위치가 5초동안 0~5m 이동 후 그 다음 50m를 넘어간다면 추후엔 저장이 안되는 이슈가 발생할 수 있습니다.
- 이 부분에 대한 추가적인 보정 고민이 필요합니다.
- 이 점을 고려해서 Kalman 필터를 추후 학습 후 적용을 해야할 듯 합니다.

## 📸 스크린샷
> 작업한 내용에 대한 스크린샷, 영상 등을 첨부합니다.
