### PR TITLE
[BE] ♻️ : BE/release -> main merge 문제 해결 시 누락된 코드 복구

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,8 +168,8 @@ node_modules
 
 
 # compiled output
-/dist
-/node_modules
+dist
+node_modules
 
 # Logs
 logs

--- a/BE/musicspot/src/common/util/coordinate.util.ts
+++ b/BE/musicspot/src/common/util/coordinate.util.ts
@@ -6,6 +6,8 @@ export const is1DArray = (arr) => {
     if (!isInCoordinateRange(arr)) {
       return false;
     }
+  } else {
+    return false;
   }
 
   return true;

--- a/BE/musicspot/src/journey/controller/journey.controller.ts
+++ b/BE/musicspot/src/journey/controller/journey.controller.ts
@@ -135,8 +135,8 @@ export class JourneyController {
     description: '사용자가 진행중이었던 여정 정보',
     type: Journey,
   })
-  @Get('loadLastData')
-  async loadLastData(@Query('userId') userId: string) {
+  @Get(':userId/last')
+  async loadLastData(@Param('userId') userId: string) {
     return await this.journeyService.loadLastJourney(userId);
   }
 

--- a/BE/musicspot/src/journey/service/journey.service.ts
+++ b/BE/musicspot/src/journey/service/journey.service.ts
@@ -193,30 +193,44 @@ export class JourneyService {
   }
 
   async loadLastJourney(userId) {
-    const user = await this.userModel.findById(userId).lean();
-
-    if (!user) {
+    const user = await this.userModel.findOne({userId}).lean();
+    if(!user){
       throw new UserNotFoundException();
     }
+
     const journeys = user.journeys;
 
-    const journey = await this.findLastJourney(journeys);
-    if (journey) {
-      return journey;
-    }
-    return '진행중이었던 여정이 없습니다.';
-  }
-  async findLastJourney(journeys) {
-    for (let i = 0; i < journeys.length; i++) {
-      let journey = await this.journeyModel.findById(journeys[i]).lean();
-      if (!journey) {
-        throw new JourneyNotFoundException();
+    const len = journeys.length;
+    const lastJourneyId = journeys[len-1];
+    
+    const lastJourney = await this.journeyModel
+      .findById(lastJourneyId)
+      .populate({
+        path: 'spots',
+        model: 'Spot',
+        options: {
+          transform: (spot) => {
+            return {
+              coordinate: spot.coordinate,
+              timestamp: spot.timestamp,
+              photoUrl: makePresignedUrl(spot.photoKey),
+            };
+          },
+        },
+      })
+      .lean();
+
+      if (!lastJourney) {
+        return {
+          journey: null,
+          isRecording: false,
+        };
       }
-      if (journey.title === '') {
-        return journey;
-      }
-    }
-    return false;
+
+      return {
+        journey: lastJourney.title ? null : lastJourney,
+        isRecording: lastJourney.title ? false : true,
+      };
   }
 
   async getJourneyById(journeyId) {

--- a/BE/musicspot/src/spot/service/spot.service.spec.ts
+++ b/BE/musicspot/src/spot/service/spot.service.spec.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import { Test, TestingModule } from '@nestjs/testing';
 import { SpotService } from './spot.service';
 import mongoose from 'mongoose';
-import { Spot, SpotSchema } from '../schema/spot.schemaㄴ';
+import { Spot, SpotSchema } from '../schema/spot.schema';
 import { getModelToken } from '@nestjs/mongoose';
 
 import { Journey, JourneySchema } from '../../journey/schema/journey.schema';

--- a/BE/musicspot/src/spot/service/spot.service.ts
+++ b/BE/musicspot/src/spot/service/spot.service.ts
@@ -38,11 +38,11 @@ export class SpotService {
   async insertToSpot(spotData) {
     const data = { ...spotData, coordinate: JSON.parse(spotData.coordinate) };
     const createdSpotData = await new this.spotModel(data).save();
-    const spotId = createdSpotData._id;
+    const {_id, coordinate} = createdSpotData;
     await this.journeyModel
       .findOneAndUpdate(
         { _id: spotData.journeyId },
-        { $push: { spots: spotId } },
+        { $push: { spots: _id ,coordinates: coordinate} },
         { new: true },
       )
       .lean();
@@ -59,7 +59,6 @@ export class SpotService {
       ...recordSpotDto,
       photoKey,
     });
-
     const { journeyId, coordinate, timestamp } = createdSpotData;
     const returnData: RecordSpotResDTO = {
       journeyId,


### PR DESCRIPTION
## ❗ 배경
> 작업 배경에 대한 설명을 작성합니다.
> Issue에 대한 링크를 첨부합니다.

BE/release를 main에 merge 시 git 사용 미숙으로 인해 iOS 코드가 BE/release로 복사된 상황

BE/temp라는 브랜치를 따로 파서 이상이 생기기 전 코드로 복구하는 과정에서 누락된 코드 복구
## 🔧 작업 내역
> 작업한 내용들을 나열합니다.
> 간결하게 리스트 업하고, 자세한 설명은 아래 리뷰 노트에서 합니다.

### 누락된 코드 복구
1. gitignore를 하나로 통일(기존에는 iOS 따로 BE 따로 있었음)
2. spot 추가 시 coordinate를 journey에도 추가 (기존에는 spot coordinate는 따로 추가가 되지 않았음)
3. Coordinate 유효성 검사하는 decorator 수정(기존에는 일반적인 문자열을 저장해도 에러를 발생하지 않았음)
4. Journey 기록 시 예외 처리 추가(coordiante의 유효성 검사를 앞부분에 추가해 나머지 로직을 진행하지 않도록 함)
5. 마지막 여정 검색 로직 수정
  - loadLastData라는 api path를 :userId/last로 수정
  - user의 모든 여정을 탐색하는 것이 아닌 마지막 여정만을 검사하도록 하는 로직으로 수정
## 📝 리뷰 노트
> 작업 내역에 대한 자세한 설명을 작성합니다.

## 📸 스크린샷
> 작업한 내용에 대한 스크린샷, 영상 등을 첨부합니다.
