### PR TITLE
[BE] ✨ : api path 변경

### DIFF
--- a/BE/musicspot/src/journey/controller/journey.controller.ts
+++ b/BE/musicspot/src/journey/controller/journey.controller.ts
@@ -341,4 +341,23 @@ export class JourneyController {
       console.log(err);
     }
   }
+
+  @ApiTags('Journey V2')
+  @Version('2')
+  @ApiOperation({
+    summary: 'journey 삭제 API',
+    description: 'journey id를 통해 journey 데이터 삭제'
+  })
+  @ApiCreatedResponse({
+    description: '여정 삭제'
+  })
+  @Delete(':journeyId')
+  async deleteJourney(@Param('journeyId') journeyId:number){
+    try{
+      return this.journeyService.deleteJourney(journeyId);
+    } catch (err){
+      console.log(err)
+    }
+  }
+
 }

--- a/BE/musicspot/src/journey/controller/journey.controller.ts
+++ b/BE/musicspot/src/journey/controller/journey.controller.ts
@@ -47,13 +47,17 @@ import {
   EndJourneyResDTOV2,
 } from '../dto/v2/endJourney.v2.dto';
 import { FilesInterceptor } from '@nestjs/platform-express';
-import { RecordSpotReqDTOV2 } from '../../spot/dto/v2/recordSpot.v2.dto';
+import {
+  RecordSpotReqDTOV2,
+  RecordSpotResDTOV2,
+} from '../../spot/dto/v2/recordSpot.v2.dto';
+import { JourneyV2DTO } from '../dto/v2/jounrey.dto';
 
 @Controller('journey')
-@ApiTags('journey 관련 API')
 export class JourneyController {
   constructor(private journeyService: JourneyService) {}
 
+  @ApiTags('Journey V1')
   @ApiOperation({
     summary: '여정 시작 API',
     description: '여정 기록을 시작합니다.',
@@ -85,6 +89,7 @@ export class JourneyController {
   //   }
   // }
 
+  @ApiTags('Journey V1')
   @ApiOperation({
     summary: '여정 종료 API',
     description: '여정을 종료합니다.',
@@ -98,6 +103,7 @@ export class JourneyController {
     return await this.journeyService.end(endJourneyReqDTO);
   }
 
+  @ApiTags('Journey V2')
   @Version('2')
   @ApiOperation({
     summary: '여정 종료 API(V2)',
@@ -108,7 +114,10 @@ export class JourneyController {
     type: EndJourneyResDTOV2,
   })
   @Post(':journeyId/end')
-  async endV2(@Param('journeyId') journeyId:number, @Body() endJourneyReqDTO: EndJourneyReqDTOV2) {
+  async endV2(
+    @Param('journeyId') journeyId: number,
+    @Body() endJourneyReqDTO: EndJourneyReqDTOV2,
+  ) {
     try {
       return await this.journeyService.endV2(journeyId, endJourneyReqDTO);
     } catch (err) {
@@ -116,6 +125,7 @@ export class JourneyController {
     }
   }
 
+  @ApiTags('Journey V1')
   @ApiOperation({
     summary: '여정 좌표 기록API',
     description: '여정의 좌표를 기록합니다.',
@@ -131,52 +141,54 @@ export class JourneyController {
     return returnData;
   }
 
-  @Version('2')
+  // @Version('2')
+  // @ApiOperation({
+  //   summary: '여정 조회 API',
+  //   description: '해당 범위 내의 여정들을 반환합니다.',
+  // })
+  // @ApiQuery({
+  //   name: 'userId',
+  //   description: '유저 ID',
+  //   required: true,
+  //   example: 'yourUserId',
+  // })
+  // @ApiQuery({
+  //   name: 'minCoordinate',
+  //   description: '최소 좌표',
+  //   required: true,
+  //   example: '37.5 127.0',
+  // })
+  // @ApiQuery({
+  //   name: 'maxCoordinate',
+  //   description: '최대 좌표',
+  //   required: true,
+  //   example: '38.0 128.0',
+  // })
+  // @ApiCreatedResponse({
+  //   description: '범위에 있는 여정의 기록들을 반환',
+  //   type: CheckJourneyResDTO,
+  // })
+  // @Get()
+  // @UsePipes(ValidationPipe)
+  // async getJourneyByCoordinate(
+  //   @Query('userId') userId: UUID,
+  //   @Query('minCoordinate') minCoordinate: string,
+  //   @Query('maxCoordinate') maxCoordinate: string,
+  // ) {
+  //   console.log('min:', minCoordinate, 'max:', maxCoordinate);
+  //   const checkJourneyDTO = {
+  //     userId,
+  //     minCoordinate,
+  //     maxCoordinate,
+  //   };
+  //   return await this.journeyService.getJourneyByCoordinationRangeV2(
+  //     checkJourneyDTO,
+  //   );
+  // }
+
+  @ApiTags('Journey V1')
   @ApiOperation({
-    summary: '여정 조회 API',
-    description: '해당 범위 내의 여정들을 반환합니다.',
-  })
-  @ApiQuery({
-    name: 'userId',
-    description: '유저 ID',
-    required: true,
-    example: 'yourUserId',
-  })
-  @ApiQuery({
-    name: 'minCoordinate',
-    description: '최소 좌표',
-    required: true,
-    example: '37.5 127.0',
-  })
-  @ApiQuery({
-    name: 'maxCoordinate',
-    description: '최대 좌표',
-    required: true,
-    example: '38.0 128.0',
-  })
-  @ApiCreatedResponse({
-    description: '범위에 있는 여정의 기록들을 반환',
-    type: CheckJourneyResDTO,
-  })
-  @Get()
-  @UsePipes(ValidationPipe)
-  async getJourneyByCoordinate(
-    @Query('userId') userId: UUID,
-    @Query('minCoordinate') minCoordinate: string,
-    @Query('maxCoordinate') maxCoordinate: string,
-  ) {
-    console.log('min:', minCoordinate, 'max:', maxCoordinate);
-    const checkJourneyDTO = {
-      userId,
-      minCoordinate,
-      maxCoordinate,
-    };
-    return await this.journeyService.getJourneyByCoordinationRangeV2(
-      checkJourneyDTO,
-    );
-  }
-  @ApiOperation({
-    summary: '여정 조회 API',
+    summary: '여정 조회 API(Coordinate 범위)',
     description: '해당 범위 내의 여정들을 반환합니다.',
   })
   @ApiQuery({
@@ -223,25 +235,27 @@ export class JourneyController {
     );
   }
 
-  @Version('2')
+  // @Version('2')
+  // @ApiOperation({
+  //   summary: '최근 여정 조회 API',
+  //   description: '진행 중인 여정이 있었는 지 확인',
+  // })
+  // @ApiCreatedResponse({
+  //   description: '사용자가 진행중이었던 여정 정보',
+  //   type: LastJourneyResDTO,
+  // })
+  // @Get('last')
+  // async loadLastDataV2(@Body('userId') userId) {
+  //   try {
+  //     return await this.journeyService.getLastJourneyByUserIdV2(userId);
+  //   } catch (err) {
+  //     console.log(err);
+  //   }
+  // }
+
+  @ApiTags('Journey V1')
   @ApiOperation({
-    summary: '최근 여정 조회 API',
-    description: '진행 중인 여정이 있었는 지 확인',
-  })
-  @ApiCreatedResponse({
-    description: '사용자가 진행중이었던 여정 정보',
-    type: LastJourneyResDTO,
-  })
-  @Get('last')
-  async loadLastDataV2(@Body('userId') userId) {
-    try {
-      return await this.journeyService.getLastJourneyByUserIdV2(userId);
-    } catch (err) {
-      console.log(err);
-    }
-  }
-  @ApiOperation({
-    summary: '최근 여정 조회 API',
+    summary: '마지막 여정 진행 중 여부 확인 API',
     description: '진행 중인 여정이 있었는 지 확인',
   })
   @ApiCreatedResponse({
@@ -252,15 +266,16 @@ export class JourneyController {
   async loadLastData(@Body('userId') userId) {
     return await this.journeyService.getLastJourneyByUserId(userId);
   }
-
+  @ApiTags('Journey V2')
   @Version('2')
   @ApiOperation({
-    summary: '여정 조회 API',
+    summary: '여정 조회 API(journeyId)',
     description: 'journey id를 통해 여정을 조회',
   })
   @ApiCreatedResponse({
     description: 'journey id에 해당하는 여정을 반환',
-    type: [Journey],
+    type: JourneyV2DTO,
+    isArray: true,
   })
   @Get(':journeyId')
   async getJourneyByIdV2(@Param('journeyId') journeyId: number) {
@@ -271,8 +286,9 @@ export class JourneyController {
     }
   }
 
+  @ApiTags('Journey V1')
   @ApiOperation({
-    summary: '여정 조회 API',
+    summary: '여정 조회 API(journeyId)',
     description: 'journey id를 통해 여정을 조회',
   })
   @ApiCreatedResponse({
@@ -284,6 +300,7 @@ export class JourneyController {
     return await this.journeyService.getJourneyById(journeyId);
   }
 
+  @ApiTags('Journey V1')
   @ApiOperation({
     summary: '여정 삭제 api',
     description: 'journey id에 따른 여정 삭제',
@@ -297,6 +314,7 @@ export class JourneyController {
     return await this.journeyService.deleteJourneyById(deleteJourneyDto);
   }
 
+  @ApiTags('Spot V2')
   @Version('2')
   @ApiOperation({
     summary: 'spot 저장 api(V2)',
@@ -304,6 +322,7 @@ export class JourneyController {
   })
   @ApiCreatedResponse({
     description: '저장된 spot을 반환(presigned url)',
+    type: RecordSpotResDTOV2,
   })
   @UseInterceptors(FilesInterceptor('images'))
   @Post(':journeyId/spot')

--- a/BE/musicspot/src/journey/controller/journey.controller.ts
+++ b/BE/musicspot/src/journey/controller/journey.controller.ts
@@ -67,23 +67,23 @@ export class JourneyController {
     return await this.journeyService.insertJourneyData(startJourneyDTO);
   }
 
-  @Version('2')
-  @ApiOperation({
-    summary: '여정 시작 API(V2)',
-    description: '여정 기록을 시작합니다.',
-  })
-  @ApiCreatedResponse({
-    description: '생성된 여정 데이터를 반환',
-    type: StartJourneyResDTOV2,
-  })
-  @Post('start')
-  async createV2(@Body() startJourneyDTO: StartJourneyReqDTOV2) {
-    try {
-      return await this.journeyService.insertJourneyDataV2(startJourneyDTO);
-    } catch (err) {
-      console.log(err);
-    }
-  }
+  // @Version('2')
+  // @ApiOperation({
+  //   summary: '여정 시작 API(V2)',
+  //   description: '여정 기록을 시작합니다.',
+  // })
+  // @ApiCreatedResponse({
+  //   description: '생성된 여정 데이터를 반환',
+  //   type: StartJourneyResDTOV2,
+  // })
+  // @Post('start')
+  // async createV2(@Body() startJourneyDTO: StartJourneyReqDTOV2) {
+  //   try {
+  //     return await this.journeyService.insertJourneyDataV2(startJourneyDTO);
+  //   } catch (err) {
+  //     console.log(err);
+  //   }
+  // }
 
   @ApiOperation({
     summary: '여정 종료 API',

--- a/BE/musicspot/src/journey/controller/journey.controller.ts
+++ b/BE/musicspot/src/journey/controller/journey.controller.ts
@@ -107,10 +107,10 @@ export class JourneyController {
     description: '여정 종료 정보 반환',
     type: EndJourneyResDTOV2,
   })
-  @Post('end')
-  async endV2(@Body() endJourneyReqDTO: EndJourneyReqDTOV2) {
+  @Post(':journeyId/end')
+  async endV2(@Param('journeyId') journeyId:number, @Body() endJourneyReqDTO: EndJourneyReqDTOV2) {
     try {
-      return await this.journeyService.endV2(endJourneyReqDTO);
+      return await this.journeyService.endV2(journeyId, endJourneyReqDTO);
     } catch (err) {
       console.log(err);
     }

--- a/BE/musicspot/src/journey/dto/journeyCheck/journeyCheck.dto.ts
+++ b/BE/musicspot/src/journey/dto/journeyCheck/journeyCheck.dto.ts
@@ -56,7 +56,7 @@ export class SpotDTO {
   readonly photoUrl: string;
 }
 
-class journeyMetadataDto {
+export class journeyMetadataDto {
   @ApiProperty({
     description: '여정 시작 시간',
     example: '2023-11-22T15:30:00.000+09:00',

--- a/BE/musicspot/src/journey/dto/v2/endJourney.v2.dto.ts
+++ b/BE/musicspot/src/journey/dto/v2/endJourney.v2.dto.ts
@@ -8,13 +8,13 @@ import {
 import { IsCoordinatesV2 } from '../../../common/decorator/coordinate.v2.decorator';
 
 export class EndJourneyReqDTOV2 {
-  @ApiProperty({
-    example: 20,
-    description: '여정 id',
-    required: true,
-  })
-  @IsNumber()
-  readonly journeyId: number;
+  // @ApiProperty({
+  //   example: 20,
+  //   description: '여정 id',
+  //   required: true,
+  // })
+  // @IsNumber()
+  // readonly journeyId: number;
 
   @ApiProperty({
     example: '37.555946 126.972384,37.555946 126.972384',

--- a/BE/musicspot/src/journey/dto/v2/endJourney.v2.dto.ts
+++ b/BE/musicspot/src/journey/dto/v2/endJourney.v2.dto.ts
@@ -1,11 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
-import {
-  IsString,
-  IsDateString,
-  IsNumber,
-  IsObject,
-} from 'class-validator';
+import { IsString, IsDateString, IsNumber, IsObject } from 'class-validator';
 import { IsCoordinatesV2 } from '../../../common/decorator/coordinate.v2.decorator';
+import { SongDTO } from '../song/song.dto';
 
 export class EndJourneyReqDTOV2 {
   // @ApiProperty({
@@ -47,6 +43,7 @@ export class EndJourneyReqDTOV2 {
   @ApiProperty({
     description: '노래 정보',
     required: true,
+    type: SongDTO,
   })
   readonly song: object;
 }
@@ -83,6 +80,7 @@ export class EndJourneyResDTOV2 {
   @ApiProperty({
     description: '노래 정보',
     required: true,
+    type: SongDTO,
   })
   readonly song: object;
 }

--- a/BE/musicspot/src/journey/dto/v2/jounrey.dto.ts
+++ b/BE/musicspot/src/journey/dto/v2/jounrey.dto.ts
@@ -1,0 +1,30 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { journeyMetadataDto, SpotDTO } from '../journeyCheck/journeyCheck.dto';
+import { SpotV2DTO } from '../../../spot/dto/v2/spot.dto';
+import { SongDTO } from '../song/song.dto';
+
+export class JourneyV2DTO {
+  @ApiProperty({ description: '여정 ID', example: '65649c91380cafcab8869ed2' })
+  readonly journeyId: string;
+
+  @ApiProperty({ description: '여정 제목', example: '여정 제목' })
+  readonly title: string;
+
+  @ApiProperty({
+    example: '37.555946 126.972384,37.555946 126.972384',
+    description: '위치 좌표',
+    required: true,
+  })
+  readonly coordinates: string;
+
+  @ApiProperty({ description: '여정 메타데이터', type: journeyMetadataDto })
+  readonly journeyMetadata: journeyMetadataDto;
+
+  @ApiProperty({ type: SpotV2DTO, description: 'spot 배열', isArray: true })
+  readonly spots: SpotV2DTO[];
+
+  @ApiProperty({ type: SongDTO, description: '여정 대표 음악' })
+  readonly song: SongDTO;
+}
+
+//

--- a/BE/musicspot/src/journey/dto/v2/lastJourney.dto.v2.ts
+++ b/BE/musicspot/src/journey/dto/v2/lastJourney.dto.v2.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { JourneyV2DTO } from './jounrey.dto';
+
+export class LastJourneyResV2DTO {
+  @ApiProperty({ description: '여정 ID', type: JourneyV2DTO })
+  readonly jounrey: JourneyV2DTO;
+
+  @ApiProperty({ description: '여정 마무리 여부' })
+  readonly isRecording: boolean;
+}

--- a/BE/musicspot/src/journey/entities/journey.v2.entity.ts
+++ b/BE/musicspot/src/journey/entities/journey.v2.entity.ts
@@ -7,7 +7,7 @@ import {
   OneToMany,
   JoinColumn,
 } from 'typeorm';
-@Entity({ name: 'journey' })
+@Entity({ name: 'journey'})
 export class JourneyV2 {
   @PrimaryGeneratedColumn()
   journeyId: number;

--- a/BE/musicspot/src/journey/service/journey.service.ts
+++ b/BE/musicspot/src/journey/service/journey.service.ts
@@ -440,12 +440,13 @@ export class JourneyService {
   }
   parseToSaveSpotResDtoFormat(spotResult, photoResult): RecordJourneyResDTO {
     return {
+      spotId: spotResult.spotId,
       ...spotResult,
       spotSong: JSON.parse(spotResult.spotSong),
-      photoKeys: photoResult.map((result) => {
+      photos: photoResult.map((result) => {
         return {
           photoId: result.photoId,
-          photoKey: makePresignedUrl(result.photoKey),
+          photoUrl: makePresignedUrl(result.photoKey),
         };
       }),
     };

--- a/BE/musicspot/src/journey/service/journey.service.ts
+++ b/BE/musicspot/src/journey/service/journey.service.ts
@@ -468,4 +468,8 @@ export class JourneyService {
 
     return this.parseToSaveSpotResDtoFormat(saveSpotResult, photoSaveReuslt);
   }
+  async deleteJourney(journeyId: number){
+    return this.journeyRepositoryV2.delete(journeyId);
+  }
+
 }

--- a/BE/musicspot/src/journey/service/journey.service.ts
+++ b/BE/musicspot/src/journey/service/journey.service.ts
@@ -135,8 +135,8 @@ export class JourneyService {
 
     return returnData;
   }
-  async endV2(endJourneyDTO: EndJourneyReqDTOV2) {
-    const { coordinates, journeyId, song } = endJourneyDTO;
+  async endV2(journeyId, endJourneyDTO: EndJourneyReqDTOV2) {
+    const { coordinates, song } = endJourneyDTO;
     const originalData = await this.journeyRepositoryV2.findOne({
       where: { journeyId },
     });
@@ -146,6 +146,7 @@ export class JourneyService {
 
     const newCoordinates = `LINESTRING(${coordinates})`;
     const newJourneyData = {
+      journeyId,
       ...originalData,
       ...endJourneyDTO,
       song: JSON.stringify(song),

--- a/BE/musicspot/src/photo/controller/photo.controller.ts
+++ b/BE/musicspot/src/photo/controller/photo.controller.ts
@@ -1,15 +1,16 @@
 import { Controller, Delete, Param, Version } from '@nestjs/common';
 import { PhotoService } from '../service/photo.service';
-import { ApiCreatedResponse, ApiOperation } from '@nestjs/swagger';
+import {ApiCreatedResponse, ApiOperation, ApiTags} from '@nestjs/swagger';
 import { StartJourneyResDTO } from '../../journey/dto/journeyStart/journeyStart.dto';
 
 @Controller('photo')
 export class PhotoController {
   constructor(private photoService: PhotoService) {}
 
+  @ApiTags('Photo V2')
   @Version('2')
   @ApiOperation({
-    summary: '여정 시작 API',
+    summary: '사진 삭제 API',
     description: '여정 기록을 시작합니다.',
   })
   @ApiCreatedResponse({

--- a/BE/musicspot/src/photo/dto/photo.dto.ts
+++ b/BE/musicspot/src/photo/dto/photo.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class PhotoDTO {
+  @ApiProperty({
+    description: 'photo Id',
+    example: '20',
+  })
+  readonly photoId: number;
+
+  @ApiProperty({
+    description: 'photo presigned url',
+    example:
+      'https://music-spot-test.kr.object.ncloudstorage.com/52/17083469749660?AWSAccessKeyId=194C0D972294FBAFCE35&Expires=1708347035&Signature=29GAH%2Fl1BcsTkYof5BUqcXPRPVU%3D',
+  })
+  readonly photoUrl: string;
+}

--- a/BE/musicspot/src/photo/entity/photo.entity.ts
+++ b/BE/musicspot/src/photo/entity/photo.entity.ts
@@ -17,7 +17,7 @@ export class Photo {
   @Column()
   photoKey: string;
 
-  @ManyToOne(() => SpotV2, (spot) => spot.photos)
+  @ManyToOne(() => SpotV2, (spot) => spot.photos, {onDelete: 'CASCADE'})
   @JoinColumn({ name: 'spotId' })
   spot: SpotV2;
 }

--- a/BE/musicspot/src/spot/controller/spot.controller.ts
+++ b/BE/musicspot/src/spot/controller/spot.controller.ts
@@ -19,10 +19,10 @@ import { SpotDTO } from 'src/journey/dto/journeyCheck/journeyCheck.dto';
 import { RecordSpotReqDTOV2 } from '../dto/v2/recordSpot.v2.dto';
 import { Photo } from '../../photo/entity/photo.entity';
 @Controller('spot')
-@ApiTags('spot 관련 API')
 export class SpotController {
   constructor(private spotService: SpotService) {}
 
+  @ApiTags('Spot V1')
   @ApiOperation({
     summary: 'spot 기록 API',
     description: 'spot을 기록합니다.',
@@ -40,27 +40,29 @@ export class SpotController {
     return await this.spotService.create(file, recordSpotDTO);
   }
 
-  @Version('2')
-  @ApiOperation({
-    summary: 'photo 저장 api',
-    description: 'photo를 기록합니다.',
-  })
-  @ApiCreatedResponse({
-    description: 'photo 생성 데이터 반환',
-    type: Photo,
-  })
-  @UseInterceptors(FilesInterceptor('images'))
-  @Post(':spotId/photo')
-  async savePhoto(
-    @UploadedFiles() images: Array<Express.Multer.File>,
-    @Param('spotId') spotId: number,
-  ) {
-    try {
-      return this.spotService.savePhoto(images, spotId);
-    } catch (err) {
-      console.log(err);
-    }
-  }
+  // @Version('2')
+  // @ApiOperation({
+  //   summary: 'photo 저장 api',
+  //   description: 'photo를 기록합니다.',
+  // })
+  // @ApiCreatedResponse({
+  //   description: 'photo 생성 데이터 반환',
+  //   type: Photo,
+  // })
+  // @UseInterceptors(FilesInterceptor('images'))
+  // @Post(':spotId/photo')
+  // async savePhoto(
+  //   @UploadedFiles() images: Array<Express.Multer.File>,
+  //   @Param('spotId') spotId: number,
+  // ) {
+  //   try {
+  //     return this.spotService.savePhoto(images, spotId);
+  //   } catch (err) {
+  //     console.log(err);
+  //   }
+  // }
+
+  @ApiTags('Spot V1')
   @ApiOperation({
     summary: 'spot 조회 API',
     description: 'spotId로 스팟 이미지를 조회합니다.',

--- a/BE/musicspot/src/spot/dto/v2/recordSpot.v2.dto.ts
+++ b/BE/musicspot/src/spot/dto/v2/recordSpot.v2.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
-import {IsDateString, IsNumber, IsObject, IsString} from 'class-validator';
+import { IsDateString, IsString } from 'class-validator';
 import { IsCoordinateV2 } from '../../../common/decorator/coordinate.v2.decorator';
+import { SongDTO } from '../../../journey/dto/song/song.dto';
 
 export class RecordSpotReqDTOV2 {
   @ApiProperty({
@@ -26,7 +27,38 @@ export class RecordSpotReqDTOV2 {
   readonly spotSong: string;
 }
 
+const spotSongEx = {
+  id: '655efda2fdc81cae36d20650',
+  name: 'super shy',
+  artistName: 'newjeans',
+  artwork: {
+    width: 3000,
+    height: 3000,
+    url: 'https://is3-ssl.mzstatic.com/image/thumb/Music125/v4/0b/b2/52/0bb2524d-ecfc-1bae-9c1e-218c978d7072/Honeymoon_3K.jpg/{w}x{h}bb.jpg',
+    bgColor: '3000',
+  },
+};
+export class Photo {
+  @ApiProperty({
+    description: 'photo Id',
+    example: '20',
+  })
+  readonly photoId: number;
+
+  @ApiProperty({
+    description: 'photo presigned url',
+    example:
+      'https://music-spot-test.kr.object.ncloudstorage.com/52/17083469749660?AWSAccessKeyId=194C0D972294FBAFCE35&Expires=1708347035&Signature=29GAH%2Fl1BcsTkYof5BUqcXPRPVU%3D',
+  })
+  readonly photoUrl: string;
+}
 export class RecordSpotResDTOV2 {
+  @ApiProperty({
+    example: 20,
+    description: 'spot id',
+  })
+  readonly spotId: number;
+
   @ApiProperty({
     example: 20,
     description: '여정 id',
@@ -51,8 +83,20 @@ export class RecordSpotResDTOV2 {
   @ApiProperty({
     example:
       'https://music-spot-storage.kr.object.ncloudstorage.com/path/name?AWSAccessKeyId=key&Expires=1701850233&Signature=signature',
-    description: 'presigned url',
-    required: true,
+    description: 'photo key(V1만 유효)',
   })
   readonly photoUrl: string;
+
+  @ApiProperty({
+    description: 'spot 별 음악(V2)',
+    type: SongDTO,
+  })
+  readonly spotSong;
+
+  @ApiProperty({
+    description: 'photo의 url 모음',
+    type: Photo,
+    isArray: true,
+  })
+  readonly photos: Photo[];
 }

--- a/BE/musicspot/src/spot/dto/v2/spot.dto.ts
+++ b/BE/musicspot/src/spot/dto/v2/spot.dto.ts
@@ -1,0 +1,51 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { SongDTO } from '../../../journey/dto/song/song.dto';
+import { PhotoDTO } from '../../../photo/dto/photo.dto';
+
+export class SpotV2DTO {
+  @ApiProperty({
+    example: 20,
+    description: 'spot id',
+  })
+  readonly spotId: number;
+
+  @ApiProperty({
+    example: 20,
+    description: '여정 id',
+    required: true,
+  })
+  readonly journeyId: number;
+
+  @ApiProperty({
+    example: '37.555946 126.972384',
+    description: '위치 좌표',
+    required: true,
+  })
+  readonly coordinate: string;
+
+  @ApiProperty({
+    example: '2023-11-22T12:00:00Z',
+    description: 'timestamp',
+    required: true,
+  })
+  readonly timestamp: string;
+
+  @ApiProperty({
+    example: null,
+    description: 'photo key(V1만 유효)',
+  })
+  readonly photoKey: string;
+
+  @ApiProperty({
+    description: 'spot 별 음악(V2)',
+    type: SongDTO,
+  })
+  readonly spotSong;
+
+  @ApiProperty({
+    description: 'photo의 url 모음',
+    type: PhotoDTO,
+    isArray: true,
+  })
+  readonly photos: PhotoDTO[];
+}

--- a/BE/musicspot/src/spot/entities/spot.v2.entity.ts
+++ b/BE/musicspot/src/spot/entities/spot.v2.entity.ts
@@ -32,8 +32,8 @@ export class SpotV2 {
   @Column()
   spotSong: string;
 
-  @ManyToOne(() => JourneyV2, (journey) => journey.spots)
-  @JoinColumn({ name: 'journeyId' })
+  @ManyToOne(() => JourneyV2, (journey) => journey.spots, { onDelete: 'CASCADE'})
+  @JoinColumn({ name: 'journeyId', referencedColumnName:'journeyId' })
   journey: JourneyV2;
 
   @OneToMany(() => Photo, (photo) => photo.spot)

--- a/BE/musicspot/src/user/controller/user.controller.ts
+++ b/BE/musicspot/src/user/controller/user.controller.ts
@@ -22,6 +22,7 @@ import { StartJourneyRequestDTOV2 } from '../dto/startJourney.dto';
 import { Journey } from '../../journey/entities/journey.entity';
 import { CheckJourneyResDTO } from '../../journey/dto/journeyCheck/journeyCheck.dto';
 import { UUID } from 'crypto';
+import { LastJourneyResDTO } from '../../journey/dto/journeyLast.dto';
 
 @Controller('user')
 @ApiTags('user 관련 API')
@@ -101,5 +102,22 @@ export class UserController {
     return await this.userService.getJourneyByCoordinationRangeV2(
       checkJourneyDTO,
     );
+  }
+  @Version('2')
+  @ApiOperation({
+    summary: '최근 여정 조회 API',
+    description: '진행 중인 여정이 있었는 지 확인',
+  })
+  @ApiCreatedResponse({
+    description: '사용자가 진행중이었던 여정 정보',
+    type: LastJourneyResDTO,
+  })
+  @Get(':userId/journey/last')
+  async loadLastDataV2(@Param('userId') userId: UUID) {
+    try {
+      return await this.userService.getLastJourneyByUserIdV2(userId);
+    } catch (err) {
+      console.log(err);
+    }
   }
 }

--- a/BE/musicspot/src/user/controller/user.controller.ts
+++ b/BE/musicspot/src/user/controller/user.controller.ts
@@ -1,8 +1,10 @@
-import { Controller, Body, Post } from '@nestjs/common';
+import {Controller, Body, Post, Param, Version} from '@nestjs/common';
 import { UserService } from '../serivce/user.service';
 import { CreateUserDTO } from '../dto/createUser.dto';
 import { ApiCreatedResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { User } from '../entities/user.entity';
+import {StartJourneyRequestDTOV2} from "../dto/startJourney.dto";
+import {Journey} from "../../journey/entities/journey.entity";
 
 @Controller('user')
 @ApiTags('user 관련 API')
@@ -20,5 +22,20 @@ export class UserController {
   @Post()
   async create(@Body() createUserDto: CreateUserDTO): Promise<User> {
     return await this.userService.create(createUserDto);
+  }
+
+
+  @Version('2')
+  @ApiOperation({
+    summary: '여정 시작 API',
+    description: '여정을 시작합니다.',
+  })
+  @ApiCreatedResponse({
+    description: '생성된 여정 데이터를 반환',
+    type: Journey,
+  })
+  @Post(':userId/journey')
+  async startJourney(@Param('userId') userId:string, @Body() startJourneyDto: StartJourneyRequestDTOV2) {
+    return await this.userService.startJourney(userId, startJourneyDto);
   }
 }

--- a/BE/musicspot/src/user/controller/user.controller.ts
+++ b/BE/musicspot/src/user/controller/user.controller.ts
@@ -34,7 +34,7 @@ export class UserController {
     description: '생성된 여정 데이터를 반환',
     type: Journey,
   })
-  @Post(':userId/journey')
+  @Post(':userId/journey/start')
   async startJourney(@Param('userId') userId:string, @Body() startJourneyDto: StartJourneyRequestDTOV2) {
     return await this.userService.startJourney(userId, startJourneyDto);
   }

--- a/BE/musicspot/src/user/dto/startJourney.dto.ts
+++ b/BE/musicspot/src/user/dto/startJourney.dto.ts
@@ -1,0 +1,27 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsDateString, IsUUID } from 'class-validator';
+import { UUID } from 'crypto';
+
+export class StartJourneyRequestDTOV2 {
+    @ApiProperty({
+        example: '2023-11-22T12:00:00Z',
+        description: '시작 timestamp',
+        required: true,
+    })
+    @IsDateString()
+    readonly startTimestamp: string;
+}
+
+export class StartJourneyResponseDTOV2 {
+    @ApiProperty({
+        example: 20,
+        description: '저장한 journey id',
+    })
+    readonly journeyId: number;
+
+    @ApiProperty({
+        example: '2023-11-22T12:00:00Z',
+        description: 'timestamp',
+    })
+    readonly startTimestamp: string;
+}

--- a/BE/musicspot/src/user/dto/startJourney.dto.ts
+++ b/BE/musicspot/src/user/dto/startJourney.dto.ts
@@ -3,25 +3,31 @@ import { IsDateString, IsUUID } from 'class-validator';
 import { UUID } from 'crypto';
 
 export class StartJourneyRequestDTOV2 {
-    @ApiProperty({
-        example: '2023-11-22T12:00:00Z',
-        description: '시작 timestamp',
-        required: true,
-    })
-    @IsDateString()
-    readonly startTimestamp: string;
+  @ApiProperty({
+    example: '2023-11-22T12:00:00Z',
+    description: '시작 timestamp',
+    required: true,
+  })
+  @IsDateString()
+  readonly startTimestamp: string;
 }
 
 export class StartJourneyResponseDTOV2 {
-    @ApiProperty({
-        example: 20,
-        description: '저장한 journey id',
-    })
-    readonly journeyId: number;
+  @ApiProperty({
+    example: '0f8fad5b-d9cb-469f-a165-708677289501',
+    description: 'user id',
+  })
+  readonly userId: UUID;
 
-    @ApiProperty({
-        example: '2023-11-22T12:00:00Z',
-        description: 'timestamp',
-    })
-    readonly startTimestamp: string;
+  @ApiProperty({
+    example: 20,
+    description: '저장한 journey id',
+  })
+  readonly journeyId: number;
+
+  @ApiProperty({
+    example: '2023-11-22T12:00:00Z',
+    description: 'timestamp',
+  })
+  readonly startTimestamp: string;
 }

--- a/BE/musicspot/src/user/module/user.module.ts
+++ b/BE/musicspot/src/user/module/user.module.ts
@@ -7,12 +7,14 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { UserRepository } from '../repository/user.repository';
 import { TypeOrmExModule } from 'src/dynamic.module';
 import { User } from '../entities/user.entity';
+import {Journey} from "../../journey/entities/journey.entity";
+import {JourneyV2} from "../../journey/entities/journey.v2.entity";
 
 @Module({
   imports: [
     // TypeOrmExModule.forFeature([UserRepository])
     // MongooseModule.forFeature([{ name: User.name, schema: UserSchema }]),
-    TypeOrmModule.forFeature([User]),
+    TypeOrmModule.forFeature([User, JourneyV2]),
   ],
   controllers: [UserController],
   providers: [UserService],

--- a/BE/musicspot/src/user/serivce/user.service.ts
+++ b/BE/musicspot/src/user/serivce/user.service.ts
@@ -118,6 +118,7 @@ export class UserService {
       )
       .where('userId = :userId', { userId })
       .getMany();
+    console.log(returnedData);
     return returnedData.map((data) => {
       return this.parseJourneyFromEntityToDtoV2(data);
     });

--- a/BE/musicspot/src/user/serivce/user.service.ts
+++ b/BE/musicspot/src/user/serivce/user.service.ts
@@ -1,17 +1,30 @@
-import {Injectable, Version} from '@nestjs/common';
+import { Injectable, Version } from '@nestjs/common';
 import { Model } from 'mongoose';
 import { InjectModel } from '@nestjs/mongoose';
 // import { User } from '../schema/user.schema';
 import { UUID } from 'crypto';
 import { CreateUserDTO } from '../dto/createUser.dto';
-import {UserAlreadyExistException, UserNotFoundException} from '../../filters/user.exception';
+import {
+  UserAlreadyExistException,
+  UserNotFoundException,
+} from '../../filters/user.exception';
 import { UserRepository } from '../repository/user.repository';
 import { InjectRepository } from '@nestjs/typeorm';
 import { User } from '../entities/user.entity';
 import { Repository } from 'typeorm';
-import {Journey} from "../../journey/entities/journey.entity";
-import {JourneyV2} from "../../journey/entities/journey.v2.entity";
-import {StartJourneyRequestDTOV2, StartJourneyResponseDTOV2} from "../dto/startJourney.dto";
+import { Journey } from '../../journey/entities/journey.entity';
+import { JourneyV2 } from '../../journey/entities/journey.v2.entity';
+import {
+  StartJourneyRequestDTOV2,
+  StartJourneyResponseDTOV2,
+} from '../dto/startJourney.dto';
+import {
+  isPointString,
+  parseCoordinateFromGeoToDtoV2,
+  parseCoordinatesFromGeoToDtoV2,
+} from '../../common/util/coordinate.v2.util';
+import { coordinateNotCorrectException } from '../../filters/journey.exception';
+import { makePresignedUrl } from '../../common/s3/objectStorage';
 // @Injectable()
 // export class UserService {
 //   constructor(@InjectModel(User.name) private userModel: Model<User>) {}
@@ -48,7 +61,8 @@ export class UserService {
   // constructor(private userRepository: UserRepository){}
   constructor(
     @InjectRepository(User) private userRepository: Repository<User>,
-    @InjectRepository(JourneyV2) private journeyRepository: Repository<JourneyV2>
+    @InjectRepository(JourneyV2)
+    private journeyRepositoryV2: Repository<JourneyV2>,
   ) {}
   async create(
     createUserDto: CreateUserDTO,
@@ -60,16 +74,87 @@ export class UserService {
     return await this.userRepository.save(createUserDto);
   }
 
-
-  async startJourney(userId, startJourneyDto:StartJourneyRequestDTOV2) {
-    if(!await this.userRepository.findOne({where: {userId}})){
+  async startJourney(userId, startJourneyDto: StartJourneyRequestDTOV2) {
+    if (!(await this.userRepository.findOne({ where: { userId } }))) {
       throw new UserNotFoundException();
     }
 
     const journeyData = {
       userId,
-      ...startJourneyDto
+      ...startJourneyDto,
+    };
+    return await this.journeyRepositoryV2.save(journeyData);
+  }
+  async getJourneyByCoordinationRangeV2(checkJourneyDTO) {
+    const { userId, minCoordinate, maxCoordinate } = checkJourneyDTO;
+    if (!(await this.userRepository.findOne({ where: { userId } }))) {
+      throw new UserNotFoundException();
     }
-    return await this.journeyRepository.save(journeyData);
+
+    if (!(isPointString(minCoordinate) && isPointString(maxCoordinate))) {
+      throw new coordinateNotCorrectException();
+    }
+
+    const [xMinCoordinate, yMinCoordinate] = minCoordinate
+      .split(' ')
+      .map((str) => Number(str));
+    const [xMaxCoordinate, yMaxCoordinate] = maxCoordinate
+      .split(' ')
+      .map((str) => Number(str));
+    console.log(xMinCoordinate, yMinCoordinate, xMaxCoordinate, yMaxCoordinate);
+    const coordinatesRange = {
+      xMinCoordinate,
+      yMinCoordinate,
+      xMaxCoordinate,
+      yMaxCoordinate,
+    };
+    const returnedData = await this.journeyRepositoryV2
+      .createQueryBuilder('journey')
+      .leftJoinAndSelect('journey.spots', 'spot')
+      .leftJoinAndSelect('spot.photos', 'photo')
+      .where(
+        `st_within(coordinates, ST_PolygonFromText('POLYGON((:xMinCoordinate :yMinCoordinate, :xMaxCoordinate :yMinCoordinate, :xMaxCoordinate :yMaxCoordinate, :xMinCoordinate :yMaxCoordinate, :xMinCoordinate :yMinCoordinate))'))`,
+        coordinatesRange,
+      )
+      .where('userId = :userId', { userId })
+      .getMany();
+    return returnedData.map((data) => {
+      return this.parseJourneyFromEntityToDtoV2(data);
+    });
+  }
+
+  parseJourneyFromEntityToDtoV2(journey) {
+    const {
+      journeyId,
+      coordinates,
+      startTimestamp,
+      endTimestamp,
+      song,
+      title,
+      spots,
+    } = journey;
+    return {
+      journeyId,
+      coordinates: parseCoordinatesFromGeoToDtoV2(coordinates),
+      title,
+      journeyMetadata: {
+        startTimestamp,
+        endTimestamp,
+      },
+      song: JSON.parse(song),
+      spots: spots.map((spot) => {
+        return {
+          ...spot,
+          coordinate: parseCoordinateFromGeoToDtoV2(spot.coordinate),
+          spotSong: JSON.parse(spot.spotSong),
+          photos: spot.photos.map((photo) => {
+            return {
+              ...photo,
+              photoUrl: makePresignedUrl(photo.photoKey),
+            };
+          }),
+        };
+      }),
+    };
   }
 }

--- a/BE/musicspot/src/user/serivce/user.service.ts
+++ b/BE/musicspot/src/user/serivce/user.service.ts
@@ -4,7 +4,7 @@ import { InjectModel } from '@nestjs/mongoose';
 // import { User } from '../schema/user.schema';
 import { UUID } from 'crypto';
 import { CreateUserDTO } from '../dto/createUser.dto';
-import { UserAlreadyExistException } from '../../filters/user.exception';
+import {UserAlreadyExistException, UserNotFoundException} from '../../filters/user.exception';
 import { UserRepository } from '../repository/user.repository';
 import { InjectRepository } from '@nestjs/typeorm';
 import { User } from '../entities/user.entity';
@@ -62,6 +62,10 @@ export class UserService {
 
 
   async startJourney(userId, startJourneyDto:StartJourneyRequestDTOV2) {
+    if(!await this.userRepository.findOne({where: {userId}})){
+      throw new UserNotFoundException();
+    }
+
     const journeyData = {
       userId,
       ...startJourneyDto

--- a/BE/musicspot/src/user/serivce/user.service.ts
+++ b/BE/musicspot/src/user/serivce/user.service.ts
@@ -11,7 +11,7 @@ import {
 import { UserRepository } from '../repository/user.repository';
 import { InjectRepository } from '@nestjs/typeorm';
 import { User } from '../entities/user.entity';
-import { Repository } from 'typeorm';
+import {Not, Repository, IsNull} from 'typeorm';
 import { Journey } from '../../journey/entities/journey.entity';
 import { JourneyV2 } from '../../journey/entities/journey.v2.entity';
 import {
@@ -117,6 +117,7 @@ export class UserService {
         coordinatesRange,
       )
       .where('userId = :userId', { userId })
+        .andWhere('journey.title is not null')
       .getMany();
     console.log(returnedData);
     return returnedData.map((data) => {

--- a/BE/musicspot/src/user/serivce/user.service.ts
+++ b/BE/musicspot/src/user/serivce/user.service.ts
@@ -157,4 +157,35 @@ export class UserService {
       }),
     };
   }
+  async getLastJourneyByUserIdV2(userId) {
+    // const journeys = await this.journeyRepositoryV2
+    //   .createQueryBuilder('journey')
+    //   .where({ userId })
+    //   .leftJoinAndSelect('journey.spots', 'spot')
+    //   .leftJoinAndSelect('spot.photos', 'photo')
+    //   .getMany();
+    const journey = await this.journeyRepositoryV2.findOne({
+      order: { journeyId: 'DESC' },
+      where: { userId },
+      relations: ['spots', 'spots.photos'],
+    });
+    if (!journey) {
+      return {
+        journey: null,
+        isRecording: false,
+      };
+    }
+
+    // const journeyLen = journeys.length;
+    // const lastJourneyData = journeys[journeyLen - 1];
+
+    if (journey.title) {
+      return { journey: null, isRecording: false };
+    }
+
+    return {
+      journey,
+      isRecording: true,
+    };
+  }
 }

--- a/BE/musicspot/src/user/serivce/user.service.ts
+++ b/BE/musicspot/src/user/serivce/user.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import {Injectable, Version} from '@nestjs/common';
 import { Model } from 'mongoose';
 import { InjectModel } from '@nestjs/mongoose';
 // import { User } from '../schema/user.schema';
@@ -9,6 +9,9 @@ import { UserRepository } from '../repository/user.repository';
 import { InjectRepository } from '@nestjs/typeorm';
 import { User } from '../entities/user.entity';
 import { Repository } from 'typeorm';
+import {Journey} from "../../journey/entities/journey.entity";
+import {JourneyV2} from "../../journey/entities/journey.v2.entity";
+import {StartJourneyRequestDTOV2, StartJourneyResponseDTOV2} from "../dto/startJourney.dto";
 // @Injectable()
 // export class UserService {
 //   constructor(@InjectModel(User.name) private userModel: Model<User>) {}
@@ -45,6 +48,7 @@ export class UserService {
   // constructor(private userRepository: UserRepository){}
   constructor(
     @InjectRepository(User) private userRepository: Repository<User>,
+    @InjectRepository(JourneyV2) private journeyRepository: Repository<JourneyV2>
   ) {}
   async create(
     createUserDto: CreateUserDTO,
@@ -54,5 +58,14 @@ export class UserService {
       throw new UserAlreadyExistException();
     }
     return await this.userRepository.save(createUserDto);
+  }
+
+
+  async startJourney(userId, startJourneyDto:StartJourneyRequestDTOV2) {
+    const journeyData = {
+      userId,
+      ...startJourneyDto
+    }
+    return await this.journeyRepository.save(journeyData);
   }
 }


### PR DESCRIPTION
## ❗ 배경
> 작업 배경에 대한 설명을 작성합니다.
> Issue에 대한 링크를 첨부합니다.

- #362 

## 🔧 작업 내역
> 작업한 내용들을 나열합니다.
> 간결하게 리스트 업하고, 자세한 설명은 아래 리뷰 노트에서 합니다.

### api path 수정

### swagger 수정

### coordinate range를 이용한 여정 조회 비지니스 로직 수정

### casecade 적용
## 📝 리뷰 노트
> 작업 내역에 대한 자세한 설명을 작성합니다.

### api path 수정
기존의 api는 api만으로 어떤 작업을 수행할 지 모호했습니다.
기존 body에 들어가는 id를 path로 적용함으로써 테이블의 관계를 api를 통해 보다 더 잘 표현할 수 있도록 했습니다.

1. 여정 시작 
- POST journey/start
- POST user/{userId}/journey/start

2. 여정 종료
- POST journey/end
- POST journey/{journeyId}/end

3. 여정 조회(coordiante range)
- GET journey?userId&minCoordinate&maxCoordinate
- GET user/{userId}/journey?minCoordinate&maxCoordinate

4. 마지막 여정 진행 여부 확인 
- GET journey/last
- GET user/{userId}/journey?minCoordinate&maxCoordinate


### swagger 수정
api version 2 적용에 따라 기존 api에 적용하던 dto 및 entity를 새로 만들어 적용한 api가 존재했습니다.
그래서 swagger의 전반적인 수정을 진행했습니다.

기존 api 문서는 table 입출력을 기준으로 나눠 api 마다 api tag를 달아두면 따로 수정할 필요가 없었습니다. 
이번 api 변경에 따라 테이블을 기준으로 나누는 것은 api 문서의 가독성을 해친다고 판단해서 controller router마다 api tag를 따로 지정해 분류했습니다.

### coordinate range를 이용한 여정 조회 비지니스 로직 수정
기존 range를 통한 journey 조회 시 진행 중인 journey가 있을 시 오류가 발생했습니다.

원인은 진행 중인 journey는 모든 필수 데이터가 채워지지 않아 null의 데이터를 통해 로직을 수행하는 과정에서 생겼습니다.
그래서 typeorm의 NOT(IsNull())f를 통해 완료되지 않은 journey는 불러오지 않도록 수정했습니다.

### casecade 적용
journey를 삭제하는 과정에서 foreign key 설정에서 on delete가 restrict로 되어 있어 journey 삭제 로직이 오류를 발생시켰습니다.

entity에 casecade를 적용하고 mysql의 workbench를 통해 restrict에서 casecade로 변경하여 적용했습니다.


## 📸 스크린샷

