### PR TITLE
[iOS] DesignSystem 수정

### DIFF
--- a/iOS/MSFusion/Sources/MSDesignSystem/Font/MSFont.swift
+++ b/iOS/MSFusion/Sources/MSDesignSystem/Font/MSFont.swift
@@ -21,7 +21,7 @@ public enum MSFont {
     
     // MARK: - Functions
     
-    internal var fontDetails: (fontName: String, size: CGFloat) {
+    package var fontDetails: (fontName: String, size: CGFloat) {
         switch self {
         case .superTitle: return ("Pretendard-Bold", 34.0)
         case .duperTitle: return ("Pretendard-Bold", 28.0)

--- a/iOS/MSFusion/Sources/MSSwiftUI/DesignSystem+SwiftUI/MSColor+SwiftUI.swift
+++ b/iOS/MSFusion/Sources/MSSwiftUI/DesignSystem+SwiftUI/MSColor+SwiftUI.swift
@@ -7,6 +7,8 @@
 
 import SwiftUI
 
+import MSDesignSystem
+
 extension Color {
     
     public static func msColor(_ color: MSColor) -> Color {

--- a/iOS/MSFusion/Sources/MSSwiftUI/DesignSystem+SwiftUI/MSFont+SwiftUI.swift
+++ b/iOS/MSFusion/Sources/MSSwiftUI/DesignSystem+SwiftUI/MSFont+SwiftUI.swift
@@ -7,6 +7,8 @@
 
 import SwiftUI
 
+import MSDesignSystem
+
 extension MSFont {
     
     fileprivate func font() -> Font? {

--- a/iOS/MSFusion/Sources/MSSwiftUI/DesignSystem+SwiftUI/MSIcon+SwiftUI.swift
+++ b/iOS/MSFusion/Sources/MSSwiftUI/DesignSystem+SwiftUI/MSIcon+SwiftUI.swift
@@ -1,0 +1,19 @@
+//
+//  MSIcon+SwiftUI.swift
+//  MSDesignSystem
+//
+//  Created by 이창준 on 2024.02.19.
+//
+
+import SwiftUI
+
+import MSDesignSystem
+
+extension Image {
+    
+    public static func msIcon(_ icon: MSIcon) -> Image? {
+        return Image(icon.rawValue, bundle: .msDesignSystem)
+            .renderingMode(.template)
+    }
+    
+}

--- a/iOS/MSFusion/Sources/MSUIKit/DesignSystem+UIKit/MSColor+UIKit.swift
+++ b/iOS/MSFusion/Sources/MSUIKit/DesignSystem+UIKit/MSColor+UIKit.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import MSDesignSystem
+
 extension UIColor {
     
     public static func msColor(_ color: MSColor) -> UIColor {

--- a/iOS/MSFusion/Sources/MSUIKit/DesignSystem+UIKit/MSFont+UIKit.swift
+++ b/iOS/MSFusion/Sources/MSUIKit/DesignSystem+UIKit/MSFont+UIKit.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import MSDesignSystem
+
 extension MSFont {
     
     fileprivate func font() -> UIFont? {

--- a/iOS/MSFusion/Sources/MSUIKit/DesignSystem+UIKit/MSIcon+UIKit.swift
+++ b/iOS/MSFusion/Sources/MSUIKit/DesignSystem+UIKit/MSIcon+UIKit.swift
@@ -1,0 +1,19 @@
+//
+//  MSIcon+UIKit.swift
+//  MSDesignSystem
+//
+//  Created by 이창준 on 2024.02.19.
+//
+
+import UIKit
+
+import MSDesignSystem
+
+extension UIImage {
+    
+    public static func msIcon(_ icon: MSIcon) -> UIImage? {
+        return UIImage(named: icon.rawValue, in: .msDesignSystem, compatibleWith: .current)?
+            .withRenderingMode(.alwaysTemplate)
+    }
+    
+}

--- a/iOS/MSFusion/Sources/MSUIKit/MSTextField/MSTextField.swift
+++ b/iOS/MSFusion/Sources/MSUIKit/MSTextField/MSTextField.swift
@@ -55,6 +55,7 @@ public class MSTextField: UITextField {
                 return .msIcon(.lock)
             }
         }
+        
         var rightImage: UIImage? {
             switch self {
             case .none, .search:

--- a/iOS/MusicSpot.xcworkspace/contents.xcworkspacedata
+++ b/iOS/MusicSpot.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,9 @@
 <Workspace
    version = "1.0">
    <FileRef
+      location = "group:ci_scripts">
+   </FileRef>
+   <FileRef
       location = "group:MusicSpot/MusicSpot.xcodeproj">
    </FileRef>
    <Group

--- a/iOS/ci_scripts/ci_pre_xcodebuild.sh
+++ b/iOS/ci_scripts/ci_pre_xcodebuild.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+echo "Xcode Cloud 빌드를 위한 환경을 세팅합니다..."
+
+cd ..
+
+plutil -replace BaseURL -string $API_BASEURL "MSData/Sources/MSData/Resources/APIInfo.plist"
+
+exit 0


### PR DESCRIPTION

### 각 패키지로 분리

`UIKit`과 `SwiftUI`에서 사용할 수 있도록 하는 메서드들을 각각의 패키지로 이동시켜 주었습니다.

```Swift
extension Image {
    
    public static func msIcon(_ icon: MSIcon) -> Image? {
        return Image(icon.rawValue, bundle: .msDesignSystem)
            .renderingMode(.template)
    }
    
}
```

위와 같이 각각의 프레임워크에 사용하기 위한 적용 메서드를 `MSUIKit`, `MSSwiftUI` 라이브러리로 분리해 같은 이름으로 인해 타입 추론이 불가능해진 문제를 수정했습니다.
